### PR TITLE
fix(hunt-logic): Do not drop LNY hunts with event cheese before all LNY mice are caught

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -979,14 +979,14 @@
                 if (debug_logging) {window.console.log({procs: more_details});}
             }
             else if (css_class.search(/(catchfailure|catchsuccess|attractionfailure|stuck_snowball_catch)/) !== -1) {
-                if (debug_logging) {window.console.log({message: "Got a hunt record"});}
+                if (debug_logging) {window.console.log("Got a hunt record");}
                 if (Object.keys(journal).length !== 0) {
                     // When true this means extra journal entries won't be considered for this hunt's data
                     done_procs = true;
                 }
                 else if (css_class.includes('active')) {
                     journal = markup;
-                    if (debug_logging) {window.console.log({message: "Found the active hunt", journal: journal});}
+                    if (debug_logging) {window.console.log({message: "Found the active hunt", journal});}
                 }
             }
             else if (css_class.search(/linked|passive|misc/) !== -1) {
@@ -1109,16 +1109,6 @@
                 .replace(/ mouse$/i, '');  // Remove " [Mm]ouse" if it is not a part of the name (e.g. Dread Pirate Mousert)
         }
 
-        const quest = getActiveLNYQuest(user.quests);
-        if (quest && quest.has_stockpile === "found" && !quest.mice.every(boss => boss.is_caught === true)) {
-            // Ignore event cheese hunts as the player is attracting the Costumed mice in a specific order.
-            const event_cheese = Object.keys(quest.items)
-                .filter(itemName => itemName.search(/lunar_new_year\w+cheese/) >= 0)
-                .map(cheeseName => quest.items[cheeseName]);
-            if (event_cheese.some(cheese => cheese.status === "active")) {
-                return null;
-            }
-        }
         if (debug_logging) {
             debug_logs.forEach(m => window.console.log(m));
         }


### PR DESCRIPTION
That's no longer a thing!
FWIW, all of the LNY mice are still reported there, but they are now only listed with an `is_available` property (and all have the value `true`). We didn't use that property previously because the next-in-line mouse would be available even if it was the next required catch.