### PR TITLE
Update popup: Remove old links & update to https

### DIFF
--- a/src/popup2.html
+++ b/src/popup2.html
@@ -22,19 +22,10 @@
                 tsitu's Auto-Loader
             </td></tr>
             <tr><td>
-                <a href="http://dbgames.info/mousehunt/" target="_blank" class="popup-link-out">Ryonn's MH Database</a>
+                <a href="https://dbgames.info/mousehunt/" target="_blank" class="popup-link-out">Ryonn's MH Database</a>
             </td></tr>
             <tr><td id="ryonn" class="popup-link">
                 Ryonn's Tavern (auto-populated)
-            </td></tr>
-            <tr><td>
-                <a href="http://horntracker.com/" target="_blank" class="popup-link-out">HornTracker</a>
-            </td></tr>
-            <tr><td>
-                <a href="http://www.cherecwich.com/mousehunt.html" target="_blank" class="popup-link-out">Silvermane's Tools</a>
-            </td></tr>
-            <tr><td>
-                <a href="https://chrome.google.com/webstore/detail/dsxcs-mousehunt-helper/engkjbflhflegibopjicncfjpbjfldph?hl=en" target="_blank" class="popup-link-out">DSXC's MH Helper</a>
             </td></tr>
             <tr><td>
                 <a href="https://www.reddit.com/r/mousehunt/" target="_blank" class="popup-link-out">Subreddit</a>
@@ -52,7 +43,7 @@
                 <a href="https://discord.gg/E4utmBD" target="_blank" class="popup-link-out">Discord Server</a>
             </td></tr>
             <tr><td>
-                <a href="http://mhwiki.hitgrab.com/wiki/index.php/Main_Page" target="_blank" class="popup-link-out">Wiki</a>
+                <a href="https://mhwiki.hitgrab.com/wiki/index.php/Main_Page" target="_blank" class="popup-link-out">Wiki</a>
             </td></tr>
             <tr><td>
                 <a href="popup.html" class="popup-link-out""><span class="pull-left">&lt;&lt;</span>Back</a>


### PR DESCRIPTION
Removes links to out of date/failing sites such as HornTracker.

Updates Wiki & Tavern links to https.