### PR TITLE
Improve message styling

### DIFF
--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -17,11 +17,14 @@ mhhh_flash_message_div.setAttribute(
     "display:none;" +
     "z-index:100;" +
     "position:fixed;" +
-    "top:20%;" +
+    "top: 0;" +
     "background-color: white;" +
-    "padding: 10px;" +
-    "border-radius: 5px;" +
-    "box-shadow: 0 0 10px 1px black;");
+    "padding: 2em;" +
+    "width: 100%;" +
+    "text-align: center;" +
+    "box-shadow: 0px 1px 4px 0px black;" +
+    "opacity: 95%;" +
+    "font-weight: 600;");
 document.body.appendChild(mhhh_flash_message_div);
 
 // Inject main script

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -19,7 +19,8 @@ mhhh_flash_message_div.setAttribute(
     "position:fixed;" +
     "top: 0;" +
     "background-color: white;" +
-    "padding: 2em;" +
+    "padding: 1em;" +
+    "font-size: larger;"
     "width: 100%;" +
     "text-align: center;" +
     "box-shadow: 0px 1px 4px 0px black;" +

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -20,7 +20,7 @@ mhhh_flash_message_div.setAttribute(
     "top: 0;" +
     "background-color: white;" +
     "padding: 1em;" +
-    "font-size: larger;"
+    "font-size: larger;" +
     "width: 100%;" +
     "text-align: center;" +
     "box-shadow: 0px 1px 4px 0px black;" +

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -194,7 +194,8 @@
         mhhh_flash_message_div.css('left', 'calc(50% - ' + (mhhh_flash_message_div.width() / 2) + 'px)');
 
         if (type === 'success') {
-            mhhh_flash_message_div.css('background', '#90ee90');
+            mhhh_flash_message_div.css('background', 'lightgreen');
+            mhhh_flash_message_div.css('border', '1px solid green');
         } else if (type === 'error') {
             mhhh_flash_message_div.css('background', '#ffc0cb');
         } else { // warning

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -201,7 +201,7 @@
             mhhh_flash_message_div.css('border', '1px solid red');
         } else { // warning
             mhhh_flash_message_div.css('background', 'gold');
-            mhhh_flash_message_div.css('border', '1px solid darkgoldenrod');```
+            mhhh_flash_message_div.css('border', '1px solid darkgoldenrod');
         }
 
         mhhh_flash_message_div.fadeIn(() => {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -194,14 +194,11 @@
         mhhh_flash_message_div.css('left', 'calc(50% - ' + (mhhh_flash_message_div.width() / 2) + 'px)');
 
         if (type === 'success') {
-            mhhh_flash_message_div.css('background', 'lightgreen');
-            mhhh_flash_message_div.css('border', '1px solid green');
+            mhhh_flash_message_div.css('background', '#90ee90');
         } else if (type === 'error') {
-            mhhh_flash_message_div.css('background', 'pink');
-            mhhh_flash_message_div.css('border', '1px solid red');
+            mhhh_flash_message_div.css('background', '#ffc0cb');
         } else { // warning
-            mhhh_flash_message_div.css('background', 'gold');
-            mhhh_flash_message_div.css('border', '1px solid darkgoldenrod');
+            mhhh_flash_message_div.css('background', '#ffd700');
         }
 
         mhhh_flash_message_div.fadeIn(() => {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -197,7 +197,8 @@
             mhhh_flash_message_div.css('background', 'lightgreen');
             mhhh_flash_message_div.css('border', '1px solid green');
         } else if (type === 'error') {
-            mhhh_flash_message_div.css('background', '#ffc0cb');
+            mhhh_flash_message_div.css('background', 'pink');
+            mhhh_flash_message_div.css('border', '1px solid red');
         } else { // warning
             mhhh_flash_message_div.css('background', '#ffd700');
         }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -200,7 +200,8 @@
             mhhh_flash_message_div.css('background', 'pink');
             mhhh_flash_message_div.css('border', '1px solid red');
         } else { // warning
-            mhhh_flash_message_div.css('background', '#ffd700');
+            mhhh_flash_message_div.css('background', 'gold');
+            mhhh_flash_message_div.css('border', '1px solid darkgoldenrod');```
         }
 
         mhhh_flash_message_div.fadeIn(() => {


### PR DESCRIPTION
One thing I dislike about the current submission success popup is that it's very intrusive. 

I think it's important to show these messages, both for confirmation that it was sent and also it makes you feel good providing data.

This PR moves the popup to the top of the screen. Makes it a bit bigger so it fits in nicely. Also changes to colors for named colors to actual hex codes to ensure consistency between browsers/OSes/etc. Actual color values have not been changed.

Happy to change the style / size of it.

![Screen Shot 2022-10-03 at 10 28 43 AM](https://user-images.githubusercontent.com/66798/193617020-3723355c-9386-434a-bfad-7a59c4c48f6a.png)


