### PR TITLE
Add .vscode recommendations for linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         'no-unneeded-ternary': ['error'],
         'no-unused-vars': [
             'error',
-            { args: 'none' },
+            {args: 'none'},
         ],
         'no-var': ['warn'],
         'object-curly-spacing': ['error', 'never'],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
+}


### PR DESCRIPTION
More dev ergonomics.

Since linting will make PRs fail, this will add vscode settings to recommend the [microsoft/vscode-eslint](https://github.com/microsoft/vscode-eslint) extension and fix files on save.

The `eslintrc.js` might need to filter the paths to `src` since it resulted in the `{args: 'none'}` change in itself. This might be trivial and not worth fixing though.