### PR TITLE
Adding hunter_id hash to phase out hunter_id usage later

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,14 @@ jobs:
           curl ${{ env.curl_opts }} ${{ env.tsitu_cdn }}/bm-setup-fields.min.js
           curl ${{ env.curl_opts }} ${{ env.tsitu_cdn }}/bm-setup-items.min.js
 
+      - name: Pull in latest Forge
+      # https://github.com/digitalbazaar/forge
+      # TODO: Make this using `npm run update forge`
+        run:
+          mkdir -p ${{ github.workspace }}/dist/third_party/forge
+          cd ${{ github.workspace }}/dist/third_party/forge
+          curl -sSf -O -J https://cdn.jsdelivr.net/npm/node-forge@1/dist/forge.min.js
+
       - name: Auto-versioning
         if: ${{ github.event.inputs.NEW_CUSTOM_VERSION == '' }}
         run: |

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,6 +31,7 @@
     "web_accessible_resources": [
         "scripts/main.js",
         "third_party/tsitu/*",
+        "third_party/forge/*",
         "images/icon128.png"
     ],
 

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -24,26 +24,39 @@ mhhh_flash_message_div.setAttribute(
     "box-shadow: 0 0 10px 1px black;");
 document.body.appendChild(mhhh_flash_message_div);
 
+
 // Inject main script
-const s = document.createElement('script');
-s.src = chrome.runtime.getURL('scripts/main.js');
-(document.head || document.documentElement).appendChild(s);
-s.onload = () => {
-    // Display Tsitu's Loader
-    chrome.storage.sync.get({
-        tsitu_loader_on: false,
-        tsitu_loader_offset: 80,
-    }, items => {
-        if (items.tsitu_loader_on) {
-            // There must be a better way of doing this
-            window.postMessage({
-                "mhct_message": 'tsitu_loader',
-                "tsitu_loader_offset": items.tsitu_loader_offset,
-                "file_link": chrome.runtime.getURL('third_party/tsitu/bm-menu.min.js'),
-            }, "*");
-        }
-    });
-    s.remove();
+function injectMainScript() {
+    const s = document.createElement('script');
+    s.src = chrome.runtime.getURL('scripts/main.js');
+    (document.head || document.documentElement).appendChild(s);
+    s.onload = () => {
+        // Display Tsitu's Loader
+        chrome.storage.sync.get({
+            tsitu_loader_on: false,
+            tsitu_loader_offset: 80,
+        }, items => {
+            if (items.tsitu_loader_on) {
+                // There must be a better way of doing this
+                window.postMessage({
+                    "mhct_message": 'tsitu_loader',
+                    "tsitu_loader_offset": items.tsitu_loader_offset,
+                    "file_link": chrome.runtime.getURL('third_party/tsitu/bm-menu.min.js'),
+                }, "*");
+            }
+        });
+        s.remove();
+    };
+}
+
+// Inject forge (for hunter id hash)
+// https://github.com/digitalbazaar/forge (originally tested on version 1.3.1)
+const forgeElement = document.createElement('script');
+forgeElement.src = chrome.runtime.getURL('third_party/forge/forge.min.js');
+(document.head || document.documentElement).appendChild(forgeElement);
+forgeElement.onload = () => {
+    injectMainScript();
+    forgeElement.remove();
 };
 
 // Handles messages from popup or background.

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -39,16 +39,17 @@
 
     // Create hunter id hash using forge library
     // https://github.com/digitalbazaar/forge
-    let hunter_id_hash = 0;
+    let hunter_id_hash = '0';
     function createHunterIdHash() {
         if (typeof user.user_id === 'undefined') {
             alert('MHCT: Please make sure you are logged in into MH.');
             return;
         }
 
-        if (debug_logging) { console.log("hunter_id: " + user.user_id); }
+        if (debug_logging) { console.log("hunter_id: " + user.user_id.toString().trim()); }
+        // eslint-disable-next-line no-undef
         const md = forge.md.sha512.create();
-        md.update(user.user_id);
+        md.update(user.user_id.toString().trim());
         if (debug_logging) { console.log("hunter_id_hash: " + md.digest().toHex()); }
         hunter_id_hash = md.digest().toHex();
     }


### PR DESCRIPTION
using forge library (cryptojs is no longer updated as far as i can tell, and recommends this one) https://github.com/digitalbazaar/forge
- adding hunter_id_hash on all requests to server
- tested against php hash 512, and it matches (string format)
- updated publish github action, to make sure the latest forge library is packed with the extension
- moved getSettings function up, since i need to use it earlier for debug messages
- moved debug mode activated check/message up