### PR TITLE
Create Hunter Id Hash on Login

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -42,7 +42,9 @@
     let hunter_id_hash = '0';
     function createHunterIdHash() {
         if (typeof user.user_id === 'undefined') {
-            alert('MHCT: Please make sure you are logged in into MH.');
+            // No problem if user is not logged in yet.
+            // This function will be called on logins (ajaxSuccess on session.php)
+            if (debug_logging) { console.log("MHCT: User is not logged in yet."); }
             return;
         }
 
@@ -325,6 +327,8 @@
             // Triggers on Birthday Items claim, room change click (+others, perhaps).
             // Wed Jun 23 2021 22:00:00 GMT-0400 [King's Giveaway Key Vanishing date 15th])
             getSettings(settings => recordPrizePack(settings, xhr));
+        } else if (url.includes("mousehuntgame.com/managers/ajax/users/session.php")) {
+            createHunterIdHash();
         }
     });
 


### PR DESCRIPTION
Adds another handler case to `ajaxSuccess` so the hunter id hash can be refreshed on logins.

Previously, if a hunter navigated to mousehuntgame.com and logged in, the hash would still be set to '0'. If the user never hard refreshed the page (F5), then it would be possible to submit hunts with a hash of '0'.

Now if you navigate to mousehuntgame.com, it will silently continue without the alert but rely on the fact that the hash will be correctly set at login.

Closes: #235 