### PR TITLE
Extensible details + GWH 2022 Details

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -3,6 +3,7 @@ import {IntakeRejectionEngine} from "./hunt-filter/engine";
 import {ConsoleLogger, LogLevel} from './util/logger';
 import {GWHGolemAjaxHandler} from './modules/ajax-handlers/golem';
 import {HornHud} from './util/HornHud';
+import * as detailers from './modules/details';
 import * as stagers from './modules/stages';
 
 (function () {
@@ -2210,6 +2211,10 @@ import * as stagers from './modules/stages';
         "Zugzwang's Tower": calcZugzwangsTowerHuntDetails,
     };
 
+    for (const detailer of detailers.environmentDetailerModules) {
+        location_huntdetails_lookup[detailer.environment] = detailer.addDetails;
+    }
+
     /**
      * Determine additional detailed parameters that are otherwise only visible to db exports and custom views.
      * These details may eventually be migrated to help inform location-specific stages.
@@ -2230,6 +2235,7 @@ import * as stagers from './modules/stages';
             calcLNYHuntDetails,
             calcLuckyCatchHuntDetails,
             calcPillageHuntDetails,
+            ...detailers.globalDetailerModules,
         ].map((details_func) => details_func(message, user, user_post, hunt))
             .filter(details => details);
 

--- a/src/scripts/modules/details/README.md
+++ b/src/scripts/modules/details/README.md
@@ -1,4 +1,4 @@
-# Stages
+# Details
 
 Need to add a new details for to a hunt response?
 

--- a/src/scripts/modules/details/README.md
+++ b/src/scripts/modules/details/README.md
@@ -1,0 +1,43 @@
+# Stages
+
+Need to add a new details for to a hunt response?
+
+First decide whether you need to add details for a specific location, an `IEnvironmentDetailer` or details that can happen anywhere, e.g. Pillaging, Lucky Catch, some annual events (Sprint Egg Hunt), an `IDetailer`.
+
+1. Create a new file in the appropriate [environment](environment) or [global](global) folder. (You can use javascript but it's not recommended.)
+2. Create a class in your new file that implements the appropriate interface.
+   Or use one of these templates
+
+    `IDetailer`
+
+    ```typescript
+    import { type User } from '@scripts/types/hg';
+    import { type IDetailer } from '../details.types';
+
+    export class <GlobalEvent>Detailer implements IDetailer {
+        addDetails(message: any, userPre: User, userPost: User, journal: any): {} | undefined {
+
+        }
+    }
+    ```
+
+    `IEnvironmentDetailer`
+
+    ```typescript
+    import { type User } from '@scripts/types/hg';
+    import { type IEnvironmentDetailer } from '../details.types';
+
+    export class <Location>Detailer implements IEnvironmentDetailer {
+        readonly environment: string = '<Location>';
+
+        addDetails(message: any, userPre: User, userPost: User, journal: any): {} | undefined {
+
+        }
+    }
+    ```
+
+3. The `environment` field, if required, should return a string of the location , e.g., `"Valour Rift"` or `"Town of Gnawnia"`.
+4. In the `getDetails` function, optionally return a record of details to add to the hunt otherwise do nothing.
+   - `throw` an `Error` in this function (with a detailed message) if you encounter an unexpected state and wish to discard the hunt.
+5. Add the detailer to [index.ts](index.ts).
+6. Create your unit tests in the test folder!

--- a/src/scripts/modules/details/details.types.ts
+++ b/src/scripts/modules/details/details.types.ts
@@ -1,0 +1,15 @@
+import { type User } from "@scripts/types/hg";
+
+/**
+ * An object that can add hunt details.
+ */
+export interface IDetailer {
+    addDetails(message: any, userPre: User, userPost: User, journal: any): Record<any, any> | undefined;
+}
+
+export interface IEnvironmentDetailer extends IDetailer {
+    /**
+     * The location the detailer matches
+     */
+     readonly environment: string;
+}

--- a/src/scripts/modules/details/environments/iceFortress.ts
+++ b/src/scripts/modules/details/environments/iceFortress.ts
@@ -1,0 +1,16 @@
+import { type User } from '@scripts/types/hg';
+import { type IEnvironmentDetailer } from '../details.types';
+import { type QuestIceFortress } from '@scripts/types/quests/iceFortress';
+
+export class IceFortressDetailer implements IEnvironmentDetailer {
+    readonly environment: string = 'Ice Fortress';
+
+    addDetails(message: any, userPre: User, userPost: User, journal: any): {} | undefined {
+        const quest: QuestIceFortress | undefined = userPost.quests.QuestIceFortress;
+
+        if (quest == null) {
+            return;
+        }
+
+    }
+}

--- a/src/scripts/modules/details/index.ts
+++ b/src/scripts/modules/details/index.ts
@@ -1,7 +1,9 @@
 import { type IDetailer, type IEnvironmentDetailer } from './details.types';
+import { IceFortressDetailer } from './environments/iceFortress';
 
 // Detailer for specific location
 const environmentDetailerModules: IEnvironmentDetailer[]  = [
+    new IceFortressDetailer()
 ];
 
 // Detailers that don't match on location (LNY, Halloween)

--- a/src/scripts/modules/details/index.ts
+++ b/src/scripts/modules/details/index.ts
@@ -1,0 +1,11 @@
+import { type IDetailer, type IEnvironmentDetailer } from './details.types';
+
+// Detailer for specific location
+const environmentDetailerModules: IEnvironmentDetailer[]  = [
+];
+
+// Detailers that don't match on location (LNY, Halloween)
+const globalDetailerModules: IDetailer[] = [
+];
+
+export { environmentDetailerModules, globalDetailerModules }

--- a/tests/scripts/modules/details/environments/iceFortress.spec.ts
+++ b/tests/scripts/modules/details/environments/iceFortress.spec.ts
@@ -1,0 +1,14 @@
+import { IceFortressDetailer } from '@scripts/modules/details/environments/iceFortress'
+import { type User } from '@scripts/types/hg';
+
+describe('IceFortressDetailer', () => {
+    test('getDetails does nothing', () => {
+        const detailer = new IceFortressDetailer();
+        const userPost = {
+            quests: {
+                QuestIceFortress: {}
+            }
+        } as User;
+        expect(detailer.addDetails(null, {} as User, userPost, null)).toBe(undefined);
+    })
+})


### PR DESCRIPTION
PR 2 of 2 for GWH
✔ need to rebase after PR 1 is merged (**done**)
✔️ Reviewable commit-by-commit (start with commit '[Draft extensible details feature](https://github.com/m-h-c-t/mh-helper-extension/pull/270/commits/2516bbf473e85064c630eb0630da6825e0627594))

Details is `./scripts/modules/details/`. Details can be environment specific or global (LNY, halloween, pillage etc.)
- `details.ts` contains typings
  - `IDetailer` is the global detailer. Contains an `addDetails(message, pre, post, journal)`.
  - `IEnvironmentDetailer` is an `IDetailer` but with the added `environment` property to match on.
- `index.ts` same as above, but exports `environmentDetailModules` and `globalDetailModules`


