### PR TITLE
Convert Forbidden Grove staging

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1223,7 +1223,6 @@ import * as stagers from './modules/stages';
         "Frozen Vacant Lot": addFestiveCometStage,
         "Fiery Warpath": addFieryWarpathStage,
         "Floating Islands": addFloatingIslandsStage,
-        "Forbidden Grove": addForbiddenGroveStage,
         "Foreword Farm": addForewordFarmStage,
         "Fort Rox": addFortRoxStage,
         "Furoma Rift": addFuromaRiftStage,
@@ -1888,27 +1887,6 @@ import * as stagers from './modules/stages';
         if (!message.stage) {
             logger.debug("Skipping unknown Fort Rox stage", {pre_quest: quest, post_quest: user_post.quests.QuestFortRox});
             message.location = null;
-        }
-    }
-
-    /**
-     * Report the state of the door to the Realm. The user may be auto-traveled by this hunt, either
-     * due to the use of a Ripper charm while the door is open, or because the door is closed at the time
-     * of the hunt itself. If the door closes between the time HG computes the prehunt user object and when
-     * HG receives the hunt request, we should reject logging the hunt.
-     * MAYBE: Realm Ripper charm? ID = 2345, name = "chamber_cleaver_trinket"
-     * @param {Object <string, any>} message The message to be sent.
-     * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
-     * @param {Object <string, any>} user_post The user state object, after the hunt.
-     * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
-     */
-    function addForbiddenGroveStage(message, user, user_post, hunt) {
-        const was_open = user.quests.QuestForbiddenGrove.grove.is_open;
-        if (was_open != user_post.quests.QuestForbiddenGrove.grove.is_open) {
-            logger.debug("Skipping hunt during server-side door change", {user, user_post, hunt});
-            message.location = null;
-        } else {
-            message.stage = (was_open) ? "Open" : "Closed";
         }
     }
 

--- a/src/scripts/modules/ajax-handlers/sbFactory.ts
+++ b/src/scripts/modules/ajax-handlers/sbFactory.ts
@@ -36,7 +36,13 @@ export class SBFactoryAjaxHandler extends AjaxSuccessHandler {
      */
     recordSnackPack(responseJSON: HgResponseWithVendingMachine) {
         const purchase = responseJSON.vending_machine_purchase;
-        if (purchase?.type == null) {
+
+        if (!purchase) {
+            this.logger.debug('Skipped snack pack submission as this isn\'t a vending purchase');
+            return;
+        }
+
+        if (purchase.type == null) {
             this.logger.debug('Skipped Bday snack pack submission due to unhandled XHR structure');
             this.logger.warn('Unable to parse bday response', {responseJSON});
             return;

--- a/src/scripts/modules/stages/environments/forbiddenGrove.ts
+++ b/src/scripts/modules/stages/environments/forbiddenGrove.ts
@@ -9,7 +9,6 @@ export class ForbiddenGroveStager implements IStager {
      * due to the use of a Ripper charm while the door is open, or because the door is closed at the time
      * of the hunt itself. If the door closes between the time HG computes the prehunt user object and when
      * HG receives the hunt request, we should reject logging the hunt.
-     * MAYBE: Realm Ripper charm? ID = 2345, name = "chamber_cleaver_trinket"
      */
     addStage(message: any, userPre: User, userPost: User, journal: any): void {
         const preQuest = userPre.quests.QuestForbiddenGrove;
@@ -25,9 +24,13 @@ export class ForbiddenGroveStager implements IStager {
         }
 
         const was_open = preQuest.grove.is_open;
-        // Check if user was auto-traveled to AR (i.e FG quest will be null on post).
-        // If they were, we can say door was closed for hunt. Otherwise discard.
-        if ((postQuest != null) && was_open != postQuest.grove.is_open) {
+        // Check if user was auto-traveled to AR (i.e FG quest will be undefined on post).
+        // If they were, we can say door was closed for hunt.
+        if (postQuest == null) {
+            message.stage = "Closed"
+            return;
+        // Otherwise discard if doors dont match
+        } else if (was_open != postQuest.grove.is_open) {
             throw new Error('Skipping hunt during server side door change');
         }
 

--- a/src/scripts/modules/stages/environments/forbiddenGrove.ts
+++ b/src/scripts/modules/stages/environments/forbiddenGrove.ts
@@ -1,0 +1,36 @@
+import type { User } from '@scripts/types/hg';
+import type { IStager } from '../stages.types';
+
+export class ForbiddenGroveStager implements IStager {
+    readonly environment: string = 'Forbidden Grove';
+
+    /**
+     * Report the state of the door to the Realm. The user may be auto-traveled by this hunt, either
+     * due to the use of a Ripper charm while the door is open, or because the door is closed at the time
+     * of the hunt itself. If the door closes between the time HG computes the prehunt user object and when
+     * HG receives the hunt request, we should reject logging the hunt.
+     * MAYBE: Realm Ripper charm? ID = 2345, name = "chamber_cleaver_trinket"
+     */
+    addStage(message: any, userPre: User, userPost: User, journal: any): void {
+        const preQuest = userPre.quests.QuestForbiddenGrove;
+        const postQuest = userPost.quests.QuestForbiddenGrove;
+
+        if (preQuest == null) {
+            throw new Error('User is missing Forbidden Grove quest')
+        }
+
+        if (userPre.trinket_name === "Realm Ripper Charm") {
+            message.stage = "Realm Ripper Charm"
+            return;
+        }
+
+        const was_open = preQuest.grove.is_open;
+        // Check if user was auto-traveled to AR (i.e FG quest will be null on post).
+        // If they were, we can say door was closed for hunt. Otherwise discard.
+        if ((postQuest != null) && was_open != postQuest.grove.is_open) {
+            throw new Error('Skipping hunt during server side door change');
+        }
+
+        message.stage = was_open ? "Open" : "Closed";
+    }
+}

--- a/src/scripts/modules/stages/environments/superBrieFactory.ts
+++ b/src/scripts/modules/stages/environments/superBrieFactory.ts
@@ -19,7 +19,7 @@ export class SuperBrieFactoryStager implements IStager {
             throw new Error('User is in SB+ factory but quest wasn\'t found.');
         }
 
-        if (message.mouse === "Vincent, The Magnificent" || quest.factory_atts.boss_warning === true) {
+        if (quest.factory_atts.boss_warning === true) {
             message.stage = "Boss";
         } else {
             message.stage = this.roomTypeToStage[quest.factory_atts.current_room];

--- a/src/scripts/modules/stages/index.ts
+++ b/src/scripts/modules/stages/index.ts
@@ -1,8 +1,10 @@
 import { type IStager } from './stages.types';
+import { ForbiddenGroveStager } from './environments/forbiddenGrove';
 import { IceFortressStager } from './environments/iceFortress';
 import { SuperBrieFactoryStager } from './environments/superBrieFactory';
 
 const stageModules: IStager[]  = [
+    new ForbiddenGroveStager(),
     new IceFortressStager(),
     new SuperBrieFactoryStager(),
 ];

--- a/src/scripts/types/hg.ts
+++ b/src/scripts/types/hg.ts
@@ -40,7 +40,7 @@ export interface Quests {
     QuestAncientCity?: any
     QuestBalacksCove?: any
     QuestClawShotCity?: any
-    QuestForbiddenGrove?: any
+    QuestForbiddenGrove?: quests.QuestForbiddenGrove
     QuestForewordFarm?: any
     QuestFortRox?: any
     QuestHarbour?: any

--- a/src/scripts/types/quests/forbiddenGrove.ts
+++ b/src/scripts/types/quests/forbiddenGrove.ts
@@ -1,0 +1,7 @@
+
+export interface QuestForbiddenGrove {
+    grove: {
+        is_open: boolean;
+        progress: number;
+    }
+}

--- a/src/scripts/types/quests/index.ts
+++ b/src/scripts/types/quests/index.ts
@@ -1,3 +1,4 @@
+export * from '@scripts/types/quests/forbiddenGrove';
 export * from '@scripts/types/quests/iceFortress';
 export * from '@scripts/types/quests/superBrieFactory';
 export * from '@scripts/types/quests/tableOfContents';

--- a/tests/scripts/modules/ajax-handlers/sbFactory.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/sbFactory.spec.ts
@@ -26,12 +26,20 @@ describe("SBFactoryAjaxHandler", () => {
     });
 
     describe("execute", () => {
-        it('warns if response is unexpected', async () => {
-            // vending_machine_reponse missing here,
-            // but add some other data to verify that it will print out entire response
-            await handler.execute({ user_id: 4 });
+        it('logs if birthday response is not purchase', async () => {
+            await handler.execute({});
 
-            expect(logger.warn).toBeCalledWith('Unable to parse bday response', { responseJSON: { user_id: 4 } });
+            expect(logger.debug).toBeCalledWith('Skipped snack pack submission as this isn\'t a vending purchase');
+            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+        });
+
+        it('warns if response is unexpected', async () => {
+            // vending_machine_reponse.type missing here,
+            // but add some other data to verify that it will print out entire response
+            const response = { user_id: 4, vending_machine_purchase: {} }
+            await handler.execute(response);
+
+            expect(logger.warn).toBeCalledWith('Unable to parse bday response', { responseJSON: response});
             expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
         });
 

--- a/tests/scripts/modules/stages/environments/forbiddenGrove.spec.ts
+++ b/tests/scripts/modules/stages/environments/forbiddenGrove.spec.ts
@@ -1,0 +1,114 @@
+import { ForbiddenGroveStager } from "@scripts/modules/stages/environments/forbiddenGrove";
+import { User } from "@scripts/types/hg";
+
+describe("ForbiddenGroveStager", () => {
+    const stager = new ForbiddenGroveStager();
+    let defaultPre: User;
+    let defaultPost: User;
+    let defaultMessage: any = {};
+    let defaultJournal: any = {};
+
+    beforeEach(() => {
+        defaultPre = getDefaultUser();
+        defaultPost = getDefaultUser();
+        defaultMessage = {};
+        defaultJournal = {};
+    });
+
+    it("should be for the Forbidden Grove environment", () => {
+        expect(stager.environment).toBe("Forbidden Grove");
+    });
+
+    describe("addStage", () => {
+        // Possible scenarios (pre -> post)
+        // 1. Open -> Open
+        // 2. Open -> Close (server side door change) (throws)
+        // 3. Open -> moved to Acolyte Realm (server side door change, but we caught RR)
+        // 4. Closed -> Closed
+        // 5. Closed -> moved to AR
+        // 6. Open/Closed with RR charm -> moved to AR
+
+        // common act to run addStage
+        const act = (
+            message: any = defaultMessage,
+            userPre: User = defaultPre,
+            userPost: User = defaultPost,
+            journal: any = defaultJournal
+        ) => {
+            stager.addStage(message, userPre, userPost, journal);
+        };
+
+        // common assert on defaultMessage.stage
+        const assert = (expected: string) => {
+            expect(defaultMessage.stage).toBe(expected);
+        };
+
+        it("throws when quest is undefined", () => {
+            delete defaultPre.quests.QuestForbiddenGrove;
+
+            expect(() => act()).toThrowError(
+                "User is missing Forbidden Grove quest"
+            );
+        });
+
+        it("is Open when both pre and post are open", () => {
+            act(undefined, getDefaultUser());
+            assert("Open");
+        });
+
+        it("throws on server side door change", () => {
+            defaultPost.quests.QuestForbiddenGrove!.grove.is_open = false;
+
+            expect(() => act()).toThrowError(
+                "Skipping hunt during server side door change"
+            );
+        });
+
+        it("is Closed when pre open but post is now in Acolyte Realm", () => {
+            delete defaultPost.quests.QuestForbiddenGrove;
+
+            act();
+            assert("Closed");
+        });
+
+        it("is Closed when pre and post both closed", () => {
+            defaultPre.quests.QuestForbiddenGrove!.grove.is_open = false;
+            defaultPost.quests.QuestForbiddenGrove!.grove.is_open = false;
+
+            act();
+            assert("Closed");
+        });
+
+        it("pre closed and moved to AR in post", () => {
+            defaultPre.quests.QuestForbiddenGrove!.grove.is_open = false;
+            delete defaultPost.quests.QuestForbiddenGrove;
+
+            act();
+            assert("Closed");
+        });
+
+        it.each([[true], [false]])(
+            "is RR charm when pre open or closed with RR charm ",
+            (isOpen) => {
+                defaultPre.quests.QuestForbiddenGrove!.grove.is_open = isOpen;
+                defaultPre.trinket_name = "Realm Ripper Charm";
+                delete defaultPost.quests.QuestForbiddenGrove;
+
+                act();
+                assert("Realm Ripper Charm");
+            }
+        );
+    });
+});
+
+function getDefaultUser(): User {
+    return {
+        quests: {
+            QuestForbiddenGrove: {
+                grove: {
+                    is_open: true,
+                },
+            },
+        },
+    } as User;
+}

--- a/tests/scripts/modules/stages/environments/forbiddenGrove.spec.ts
+++ b/tests/scripts/modules/stages/environments/forbiddenGrove.spec.ts
@@ -79,7 +79,7 @@ describe("ForbiddenGroveStager", () => {
             assert("Closed");
         });
 
-        it("pre closed and moved to AR in post", () => {
+        it("is Closed when pre closed and moved to AR in post", () => {
             defaultPre.quests.QuestForbiddenGrove!.grove.is_open = false;
             delete defaultPost.quests.QuestForbiddenGrove;
 

--- a/tests/scripts/modules/stages/environments/superBrieFactory.spec.ts
+++ b/tests/scripts/modules/stages/environments/superBrieFactory.spec.ts
@@ -33,18 +33,6 @@ describe("SuperBrieFactoryStager", () => {
     });
 
     describe("boss", () => {
-        it("is Boss stage when pre mouse is Vincent", () => {
-            const stager = new SuperBrieFactoryStager();
-            const message = {
-                mouse: "Vincent, The Magnificent",
-            } as IntakeMessage;
-            const preUser = changeFactoryQuest(defaultUser, defaultQuest);
-
-            stager.addStage(message, preUser, defaultUser, defaultJournal);
-
-            expect(message.stage).toBe("Boss");
-        });
-
         it("is Boss stage when there is boss_warning", () => {
             const stager = new SuperBrieFactoryStager();
             const message = {} as IntakeMessage;


### PR DESCRIPTION
- Convert FG to stager
- Add tests for FG stager

This also fixes a bug when the user catches a Realm Ripper and `userPost.quests.QuestForbiddenGrove.grove.is_open` would result in a indexing error due to undefined quest.  

*Also creates a new stage called 'Realm Ripper Charm' similar to 'Softserve Charm' stage.*

---

- Only use boss_warning for sb factory stage

This was causing the post `IntakeMessage` stage to be 'Boss' when really it should be "Any Room" or one of the 4 pump rooms. 
Using the boss_warning to indicate stage fixes that.

---

- Don't log every birthday_factory request failure

birthday_factory.php is hit every time you open the vending machine and generates a warning. Move that logging to debug and warn only when purchases are unhandled.