### PR TITLE
Add rejection message intake

### DIFF
--- a/src/scripts/hunt-filter/engine.ts
+++ b/src/scripts/hunt-filter/engine.ts
@@ -51,16 +51,7 @@ export class IntakeRejectionEngine {
             return false;
         }
 
-        // Run rules. Build set of currently invalid properties
-        // { "location", "stage" }
-        const invalidProperties = new Set<(keyof IntakeMessage)>();
-        for (const rule of this.messageRules) {
-            const valid: boolean = rule.isValid(pre, post);
-            if (!valid) {
-                this.logger.debug(`Message invalid: ${rule.description}`);
-                invalidProperties.add(rule.property);
-            }
-        }
+        const invalidProperties = this.getInvalidIntakeMessageProperties(pre, post);
 
         // Don't have to run exemption rules if there are no violations
         if (invalidProperties.size === 0) {
@@ -96,6 +87,25 @@ export class IntakeRejectionEngine {
         });
 
         return false;
+    }
+
+    /**
+     * Runs the IntakeMessage rules to build a set of currently invalid properties
+     * @param pre
+     * @param post
+     * @returns {Set<(keyof IntakeMessage)>} A set of strings representing keys of invalid IntakeMessage properties
+     */
+    public getInvalidIntakeMessageProperties(pre: IntakeMessage, post: IntakeMessage): Set<(keyof IntakeMessage)> {
+        const invalidProperties = new Set<(keyof IntakeMessage)>();
+        for (const rule of this.messageRules) {
+            const valid: boolean = rule.isValid(pre, post);
+            if (!valid) {
+                this.logger.debug(`Message invalid: ${rule.description}`);
+                invalidProperties.add(rule.property);
+            }
+        }
+
+        return invalidProperties;
     }
 
     private initResponseRules() {


### PR DESCRIPTION
While we do have a spreadsheet of mice that are slipping out of their stages, there are probably more than we can think of.

When a hunt is rejected and the reason is due to the stage or location changing, send the (pre + post) location, stage, and mouse that caused it so we can code an exception for it later.

Server side PR: https://github.com/m-h-c-t/mh-hunt-helper/pull/234