### PR TITLE
Add timestamps to all server messages

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,6 +1,7 @@
 /*jslint browser:true */
 import {IntakeRejectionEngine} from "./hunt-filter/engine";
 import {ConsoleLogger, LogLevel} from './util/logger';
+import {getUnixTimestamp} from "./util/time";
 import * as successHandlers from './modules/ajax-handlers';
 import {HornHud} from './util/HornHud';
 import * as detailers from './modules/details';
@@ -482,11 +483,9 @@ import * as stagers from './modules/stages';
     // Record map mice
     function recordMap(xhr) {
         const resp = xhr.responseJSON;
-        const entry_timestamp = Math.round(Date.now() / 1000);
         if (resp.treasure_map_inventory?.relic_hunter_hint) {
             sendMessageToServer(rh_intake_url, {
                 hint: resp.treasure_map_inventory.relic_hunter_hint,
-                entry_timestamp: entry_timestamp,
             });
         }
 
@@ -501,7 +500,6 @@ import * as stagers from './modules/stages';
                 .replace(/rare /i, '')
                 .replace(/common /i, '')
                 .replace(/Ardouous/i, 'Arduous'),
-            entry_timestamp: entry_timestamp,
         };
 
         // Send to database
@@ -746,7 +744,6 @@ import * as stagers from './modules/stages';
             convertible: getItem(convertible),
             items: items.map(getItem),
             asset_package_hash: Date.now(),
-            entry_timestamp: Math.round(Date.now() / 1000),
         };
 
         // Send to database
@@ -755,6 +752,10 @@ import * as stagers from './modules/stages';
     }
 
     function sendMessageToServer(url, final_message) {
+        if (final_message.entry_timestamp == null) {
+            final_message.entry_timestamp = getUnixTimestamp();
+        }
+
         getSettings(settings => {
             if (!settings?.tracking_enabled) { return; }
             const basic_info = {

--- a/src/scripts/util/time.ts
+++ b/src/scripts/util/time.ts
@@ -1,0 +1,8 @@
+
+/**
+ * Get the current Unix timestamp
+ * @returns Seconds since epoch
+ */
+export function getUnixTimestamp(): number {
+    return Math.round(Date.now() / 1000);
+}

--- a/tests/scripts/util/time.spec.ts
+++ b/tests/scripts/util/time.spec.ts
@@ -1,0 +1,18 @@
+import {getUnixTimestamp} from "@scripts/util/time";
+
+describe('getUnixTimetamp', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should return the number of seconds since epoch', () => {
+        const millisecondsSinceEpoch = 42000;
+        jest.setSystemTime(millisecondsSinceEpoch);
+
+        expect(getUnixTimestamp()).toBe(42);
+    });
+});


### PR DESCRIPTION
- Add time util with tests
- Add timestamp to server messages if missing

I kept the timestamp grabbing process from the 'active hunt' journal entry. But I don't think it would take more than 1 second to process the hunt if we wanted to remove that as well.
