### PR TITLE
Fix detection of King's Rewards

### DIFF
--- a/src/scripts/util/HornHud.ts
+++ b/src/scripts/util/HornHud.ts
@@ -78,7 +78,7 @@ export class HornHud {
     private static getMessageTitle() {
         // Should only return title if the message is actively displaying to user
         if (this.isMessageActive()) {
-            return this.getMessageDOM()?.querySelector<HTMLElement>('.huntersHornView__messageTitle')?.textContent ?? null;
+            return this.getMessageDOM()?.querySelector<HTMLElement>('.huntersHornMessageView__title')?.textContent ?? null;
         }
 
         return null;


### PR DESCRIPTION
Fix detection of sandwich board message title

Latest update gave a suite of new messages in the "sandwich board" area
but also changed some of the CSS classes since the message area was
converted into a templated view instead.

`huntersHornView__messageTitle` -> `hunterHornMessageView_title`