### PR TITLE
Update Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ on:
     branches:
       - main
     paths:
-      - src/**
+      - '*'
+      - '!*.md'
+      - '!*.txt'
+      - .github/workflows/**
   pull_request:
     paths:
-      - src/**
-      - tests/**
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - .github/workflows/**
 
 jobs:
@@ -42,8 +46,11 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
     - name: Install
       run: npm ci
+
     - name: Lint
       run: npm run lint
 
@@ -57,13 +64,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
     - name: Install dependencies
       run: npm ci
+
     - name: Build package
       run: npm run build
+
     - name: Run tests
       env:
         CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,17 +3,65 @@ on:
   workflow_dispatch:
     inputs:
       NEW_CUSTOM_VERSION:
-        description: '(OPTIONAL) >>> LEAVE EMPTY BY DEFAULT <<< it will increment xx automatically. For Major/Minor/Custom version number (yy.mm.xx) (no leading zeros) like 1.1.1.'
+        description: |
+          (OPTIONAL) >>> LEAVE EMPTY BY DEFAULT <<< It will default to today's date in the format 'yy.mm.dd'.
+          For Major.Minor.Custom version number (NO LEADING ZEROS) e.g. 1.1.1.
         required: false
 
 jobs:
+
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      ext-version: ${{ steps.retreive-version.outputs.ext-version }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get extension version
+        id: retreive-version
+        env:
+          CUSTOM_VERSION: ${{ github.event.inputs.NEW_CUSTOM_VERSION }}
+        run: |
+          if [[ -n "${{ env.CUSTOM_VERSION}}" ]]
+          then
+            # Only match when yy.mm.dd has no leading 0's
+            if [[ "${{ env.CUSTOM_VERSION }}" =~ ^(?<year>[1-9][0-9])\.(?<month>[1-9]|1[0-2])\.(?<day>[1-9]|[1-2][0-9]|3[0-1])$ ]]; then
+              EXT_VERSION=${{ env.CUSTOM_VERSION }}
+            else
+              echo "Invalid NEW_CUSTOM_VERSION format. Leading zeros are not allowed in the year, month, or day." >&2
+              exit 1
+            fi
+          else
+            # Need to keep separate DATE var b/c $(date -d) can't parse yy.mm.dd
+            DATE=$(date)
+            EXT_VERSION=$(date -d "$DATE" +%y.%-m.%-d);
+
+            while git rev-parse "refs/tags/$EXT_VERSION" >/dev/null 2>&1; do
+              echo "Tag $EXT_VERSION already exists. Incrementing day."
+              DATE=$(date -d "$DATE + 1 day")
+              EXT_VERSION=$(date -d "$DATE" +%y.%-m.%-d);
+            done;
+
+            echo "Setting extension version to $EXT_VERSION"
+            echo "ext-version=$EXT_VERSION" >> $GITHUB_OUTPUT
+          fi
+
   CD:
     runs-on: ubuntu-latest
-
+    needs:
+      - setup
+    outputs:
+      artifact-path: ${{ steps.create-zip.outputs.artifact-path }}
     strategy:
       matrix:
-        node-version: [16.x]
-
+        node-version: [18.x]
+    env:
+      EXT_VERSION: ${{ needs.setup.outputs.ext-version }}
     steps:
       - name: Authorized by
         run: echo "${{ github.event.sender.login }}"
@@ -21,31 +69,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Auto-versioning
-        if: ${{ github.event.inputs.NEW_CUSTOM_VERSION == '' }}
-        run: |
-          echo "NEW_CREATED_VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g' | sed 's/v//')" >> $GITHUB_ENV
-
-      - name: Use custom version
-        if: ${{ github.event.inputs.NEW_CUSTOM_VERSION != '' }}
-        run: |
-          echo "NEW_CREATED_VERSION=${{ github.event.inputs.NEW_CUSTOM_VERSION }}" >> $GITHUB_ENV
-
-      - name: Tag with new version
-        id: create-tag
-        run: |
-          git tag ${{ env.NEW_CREATED_VERSION }}
-          git push --tags
-          echo "::set-output name=version-tag::${{ env.NEW_CREATED_VERSION }}"
+          cache: 'npm'
 
       - name: Update manifest
         run: |
-          echo "New Version: ${{ steps.create-tag.outputs.version-tag }}"
-          sed -i'' -e 's|"version":.*|"version": "${{ steps.create-tag.outputs.version-tag }}",|' src/manifest.json
+          echo "New Version: ${{ env.EXT_VERSION }}"
+          sed -i'' -e 's|"version":.*|"version": "${{ env.EXT_VERSION }}",|' src/manifest.json
           cat src/manifest.json
 
       - name: Install dependencies
@@ -56,24 +90,48 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: release-${{ steps.create-tag.outputs.version-tag }}
+          name: release-${{ env.EXT_VERSION }}
           path: ./dist/*
 
       - name: Zip it! zip it good!
         id: create-zip
         run: |
           mkdir build
-          zip -r ./build/release-${{ steps.create-tag.outputs.version-tag }}.zip ./dist/*
-          echo "::set-output name=artifact-name::release-${{ steps.create-tag.outputs.version-tag }}.zip"
-          echo "::set-output name=artifact-path::build/release-${{ steps.create-tag.outputs.version-tag }}.zip"
+          zip -r ./build/release-${{ env.EXT_VERSION }}.zip ./dist/*
 
       - uses: ncipollo/release-action@v1
         with:
-          name: ${{ steps.create-tag.outputs.version-tag }}
-          tag: ${{ steps.create-tag.outputs.version-tag }}
-          artifacts: ${{ steps.create-zip.outputs.artifact-path }}
+          name: ${{ env.EXT_VERSION }}
+          tag: ${{ env.EXT_VERSION }}
+          artifacts: ./build/release-${{ env.EXT_VERSION }}.zip
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag with new version
+        id: create-tag
+        run: |
+          git tag ${{ env.EXT_VERSION }}
+          git push --tags
+
+  chrome-submit:
+    name: Submit to Chrome
+    needs:
+      - setup
+      - CD
+    env:
+      EXT_VERSION: ${{ needs.setup.outputs.ext-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        name: Get extension artifact
+        with:
+          name: release-${{ env.EXT_VERSION }}
+          path: ./dist
+
+      - name: Create chrome artifact
+        run: |
+          mkdir build
+          zip -r ./build/release-${{ env.EXT_VERSION }}.zip ./dist/*
 
       - name: Upload new release zip to Chrome Webstore
         uses: Klemensas/chrome-extension-upload-action@1df3cdf4047a4789bc61a64a125994d8caf23572
@@ -81,9 +139,27 @@ jobs:
           refresh-token: ${{ secrets.CHROME_WEBSTORE_REFRESH_TOKEN }}
           client-id: ${{ secrets.CHROME_WEBSTORE_CLIENT_ID }}
           client-secret: ${{ secrets.CHROME_WEBSTORE_CLIENT_SECRET }}
-          file-name: ${{ steps.create-zip.outputs.artifact-path }}
+          file-name: ${{ needs.CD.outputs.artifact-path }}
           app-id: ${{ secrets.CHROME_WEBSTORE_ADDON_ID }}
           publish: true
 
+  firefox-submit:
+    name: Submit to Firefox
+    needs:
+      - setup
+      - CD
+    env:
+      EXT_VERSION: ${{ needs.setup.outputs.ext-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        name: Get extension artifact
+        with:
+          name: release-${{ env.EXT_VERSION }}
+          path: ./dist
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
       - name: Upload new release to Firefox Webstore
-        run: npx -y web-ext-submit@7  --channel 'listed' --source-dir ./dist/ --verbose --api-key ${{ secrets.FIREFOX_WEBSTORE_API_KEY }} --api-secret ${{ secrets.FIREFOX_WEBSTORE_API_SECRET }}
+        run: npx -y web-ext sign --use-submission-api --channel=listed --source-dir=./dist/ --verbose --api-key ${{ secrets.FIREFOX_WEBSTORE_API_KEY }} --api-secret ${{ secrets.FIREFOX_WEBSTORE_API_SECRET }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       NEW_CUSTOM_VERSION:
         description: |
-          (OPTIONAL) >>> LEAVE EMPTY BY DEFAULT <<< It will default to today's date in the format 'yy.mm.dd'.
+          (OPTIONAL) >>> LEAVE EMPTY BY DEFAULT <<< It will default to today's date in the format 'y.m.d'.
           For Major.Minor.Custom version number (NO LEADING ZEROS) e.g. 1.1.1.
         required: false
 
@@ -37,7 +37,7 @@ jobs:
               exit 1
             fi
           else
-            # Need to keep separate DATE var b/c $(date -d) can't parse yy.mm.dd
+            # Need to keep separate DATE var b/c $(date -d) can't parse y.m.d
             DATE=$(date)
             EXT_VERSION=$(date -d "$DATE" +%y.%-m.%-d);
 


### PR DESCRIPTION
- Bump CI workflow Node to latest LTS
- Cache npm packages on CI workflow
- Split publish into jobs. Remove ::set-output usage

CI workflow now runs for most files in the repo instead of just `./src/`. Excludes markdown, text, and workflow files.

The publish workflow is now split into four jobs: Setup, Build, Chrome Submit, Firefox Submit

## Publish

### Setup 
Export the extension version to github output so it can be used later.

* Checks if a custom version was supplied, verifies that it has no leading 0. 
* With no custom version, it defaults to using today's [date](https://ss64.com/bash/date.html) but will keep incrementing the day by one if that tag already exists

### CD
Build the extension and create a github release. Creates an artifact for manual extension download/submission.

Moved tagging the repo to the end just in case the job fails for any reason.

### Chrome Submit
Download the artifacts from previous job. Zip them up (since artifacts download unzipped) and submit them to store using github action (same as before).

### Firefox Submit
Download the artifacts. Submit them to store using new `--use-submission-api`. We don't need to use `web-ext-submit` anymore since the new API is up and running. See [web-ext-submit README](https://github.com/fregante/web-ext-submit#web-ext-submit-) about linked issue which is now resolved.