### PR TITLE
Fix BB standard room stage name

### DIFF
--- a/src/scripts/modules/stages/environments/bountifulBeanstalk.ts
+++ b/src/scripts/modules/stages/environments/bountifulBeanstalk.ts
@@ -21,8 +21,9 @@ export class BountifulBeanstalkStager implements IStager {
 
             // Extreme Mystery Room -> Mystery
             const room = castle.current_room.name
-                .replace(/^\w+\s/, '')
-                .replace(/\s(Bean )?Room$/, '');
+                .replace(/^(Standard|Super|Extreme|Ultimate)/, '')
+                .replace(/(Bean )?Room$/, '')
+                .trim();
 
             if (castle.is_boss_encounter) {
                 floor += " Giant";

--- a/tests/scripts/modules/stages/environments/bountifulBeanstalk.spec.ts
+++ b/tests/scripts/modules/stages/environments/bountifulBeanstalk.spec.ts
@@ -50,7 +50,9 @@ describe('Bountiful Beanstalk stages', () => {
 
     it.each`
         floorName               | roomName                              | expected
+        ${'Dungeon Floor'}      | ${'Mystery Room'}                     | ${'Dungeon - Mystery'}
         ${'Dungeon Floor'}      | ${'Standard Mystery Room'}            | ${'Dungeon - Mystery'}
+        ${'Dungeon Floor'}      | ${'Lavish Lapis Room'}                | ${'Dungeon - Lavish Lapis'}
         ${'Ballroom Floor'}     | ${'Extreme Magic Bean Room'}          | ${'Ballroom - Magic'}
         ${'Great Hall Floor'}   | ${'Ultimate Royal Ruby Bean Room'}    | ${'Great Hall - Royal Ruby'}
     `('should set stage to $expected when castle floor name is $floorName and in $roomName room', ({floorName, roomName, expected}) => {
@@ -72,6 +74,22 @@ describe('Bountiful Beanstalk stages', () => {
         stager.addStage(message, preUser, postUser, journal);
 
         expect(message.stage).toBe('Fee Fi Fo Fum Giant - English Man');
+    });
+
+    it.each`
+        floorName               | roomName                              | expected
+        ${'Dungeon Floor'}      | ${'Mystery Room'}                     | ${'Dungeon Giant - Mystery'}
+        ${'Dungeon Floor'}      | ${'Standard Mystery Room'}            | ${'Dungeon Giant - Mystery'}
+        ${'Dungeon Floor'}      | ${'Lavish Lapis Room'}                | ${'Dungeon Giant - Lavish Lapis'}
+        ${'Ballroom Floor'}     | ${'Extreme Magic Bean Room'}          | ${'Ballroom Giant - Magic'}
+        ${'Great Hall Floor'}   | ${'Ultimate Golden Goose Egg Room'}   | ${'Great Hall Giant - Golden Goose Egg'}
+    `('should set stage to $expected at $floorName boss and in $roomName room', ({floorName, roomName, expected}) => {
+        const isBossEncounter = true;
+        preUser.quests.QuestBountifulBeanstalk = createCastleAttributes({floor: floorName, room: roomName}, isBossEncounter);
+
+        stager.addStage(message, preUser, postUser, journal);
+
+        expect(message.stage).toBe(expected);
     });
 
 });


### PR DESCRIPTION
I expected the room to be named `Standard Lavish Lapis Room`, but if it's standard it just says `Lavish Lapis Room`.
So the stage ends up being `Dungeon - Lavish` instead of `Dungeon - Lavish Lapis`.