### PR TITLE
Add new BB SB+ mouse to stage exception rule

### DIFF
--- a/src/scripts/hunt-filter/exemptions/environments/bountifulBeanstalk.ts
+++ b/src/scripts/hunt-filter/exemptions/environments/bountifulBeanstalk.ts
@@ -13,6 +13,7 @@ class BeanstalkBossExemption implements IMessageExemption {
     readonly BeanstalkMice: string[] = [
         "Budrich Thornborn",
         "Leafton Beanwell",
+        "Herbaceous Bravestalk",
     ];
     readonly BeanstalkBossMouse = "Vinneus Stalkhome";
 

--- a/tests/scripts/hunt-filter/exemptions/environments/bountifulBeanstalk.spec.ts
+++ b/tests/scripts/hunt-filter/exemptions/environments/bountifulBeanstalk.spec.ts
@@ -33,9 +33,13 @@ describe('Bountiful Beanstalk exemptions', () => {
         });
 
         describe('Beanstalk', () => {
-            it('should accept on transition to boss', () => {
+            it.each([
+                'Budrich Thornborn',
+                'Leafton Beanwell',
+                'Herbaceous Bravestalk',
+            ])('should accept on transition to boss when catching %p', (mouse) => {
                 // Arrange
-                setBeanstalkQuestAttributes(false, true, 'Budrich Thornborn');
+                setBeanstalkQuestAttributes(false, true, mouse);
 
                 // Act
                 const valid = target.validateMessage(preMessage, postMessage);


### PR DESCRIPTION
Allow recording transition to Beanstalk boss when catching the new SB|+ mouse.