### PR TITLE
Fix FI Launch Pad detection

### DIFF
--- a/src/scripts/modules/stages/environments/floatingIslands.ts
+++ b/src/scripts/modules/stages/environments/floatingIslands.ts
@@ -20,7 +20,7 @@ export class FloatingIslandsStager implements IStager {
             return hsa.activated_island_mod_types.filter(t => t == type).length;
         };
 
-        const matcher = hsa.island_name.match(/^(\w+) .*$/);
+        const matcher = hsa.island_name.match(/^(Launch Pad|\w+).*$/);
         if (!matcher) {
             throw new Error('Failed to match Floating Island\'s island name.');
         }
@@ -33,6 +33,8 @@ export class FloatingIslandsStager implements IStager {
             message.stage = `${powerType} High`;
         } else if (hsa.is_vault_island) {
             message.stage = `${powerType} Palace`;
+        } else if (powerType == "Launch Pad") {
+            message.stage = 'Launch Pad';
         } else {
             throw new Error('Unknown Floating Island stage');
         }

--- a/tests/scripts/modules/stages/environments/floatingIslands.spec.ts
+++ b/tests/scripts/modules/stages/environments/floatingIslands.spec.ts
@@ -222,6 +222,15 @@ describe('Floating Islands stages', () => {
         });
     });
 
+    it('should match on Launch Pad', () => {
+        setHuntingSiteAtts({
+            island_name: 'Launch Pad',
+        });
+        stager.addStage(message, preUser, postUser, journal);
+
+        expect(message.stage).toBe('Launch Pad');
+    });
+
     function setHuntingSiteAtts(attributes: Partial<FloatingIslandHuntingSiteAtts>) {
         preUser.quests = {
             QuestFloatingIslands: {


### PR DESCRIPTION
The regex that was adding during the FI stage rework didn't match the Launch pad so it was throwing an error.