### PR TITLE
Fix settings loss on update

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -329,8 +329,17 @@
                         </div>
                     </div>
 
-                    <button id="save" type="button" class="btn btn-primary w-100 mb-4">Save</button>
-
+                    <div class="fixed-bottom p-3">
+                        <div class="container">
+                            <div class="row justify-content-center">
+                                <div class="col-12 col-lg-10 col-xl-8 mx-auto">
+                                    <button id="save" type="button" class="btn btn-primary w-100">Save</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Add bottom padding to prevent content from being hidden under fixed button -->
+                    <div class="pb-5 mb-4"></div></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The `changeUserSettings` that changes values and returns the current settings was saving to the sync even when just requesting settings. This would unintentionally write all the default settings to `storage.sync` when upgrading to a new version.

- Fix `changeUserSettings` saving default settings every call
- Add floating save button to options
