### PR TITLE
Fix chrome desktop notifications

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -126,7 +126,7 @@ function icon_timer_updateBadge(tab_id) {
                         "MHCT Horn",
                         {
                             type: "basic",
-                            iconUrl: "images/icon128.png",
+                            iconUrl: chrome.runtime.getURL("images/icon128.png"),
                             title: "MHCT Tools",
                             message: "MouseHunt Horn is ready!!! Good luck!",
                         }


### PR DESCRIPTION
Issue #615 - The icon url needed to be a url despite what it says in the docs.