### PR TITLE
Use submission service in ajax handlers

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,7 +1,6 @@
 /*jslint browser:true */
 import {IntakeRejectionEngine} from "./hunt-filter/engine";
 import {ConsoleLogger, LogLevel} from './util/logger';
-import {getUnixTimestamp} from "./util/time";
 import {EnvironmentService} from "./services/environment.service";
 import {SubmissionService} from "./services/submission.service";
 import {ApiService} from "./services/api.service";
@@ -622,7 +621,7 @@ import * as detailingFuncs from './modules/details/legacy';
             const invalidProperties = rejectionEngine.getInvalidIntakeMessageProperties(message_pre, message_post);
             if (invalidProperties.has('stage') || invalidProperties.has('location')) {
                 const rejection_message = createRejectionMessage(message_pre, message_post);
-                sendMessageToServer(environmentService.getRejectionIntakeUrl(), rejection_message);
+                submissionService.submitRejection(rejection_message);
             }
 
             return;
@@ -630,7 +629,7 @@ import * as detailingFuncs from './modules/details/legacy';
 
         logger.debug("Recording hunt", {message_var:message_pre, user_pre, user_post, hunt});
         // Upload the hunt record.
-        sendMessageToServer(environmentService.getMainIntakeUrl(), message_pre);
+        submissionService.submitHunt(message_pre);
     }
 
     // Add bonus journal entry stuff to the hunt_details
@@ -692,40 +691,6 @@ import * as detailingFuncs from './modules/details/legacy';
         }
 
         submissionService.submitItemConvertible(convertible, items);
-    }
-
-    function sendMessageToServer(url, final_message) {
-        if (final_message.entry_timestamp == null) {
-            final_message.entry_timestamp = getUnixTimestamp();
-        }
-
-        const basic_info = {
-            hunter_id_hash,
-            entry_timestamp: final_message.entry_timestamp,
-            extension_version: mhhh_version,
-            'X-Requested-By': `MHCT/${mhhh_version}`,
-        };
-
-        // Get UUID
-        $.post(`${environmentService.getBaseUrl()}/uuid.php`, basic_info).done(data => {
-            if (data) {
-                final_message.uuid = data;
-                final_message.hunter_id_hash = hunter_id_hash;
-                final_message.extension_version = mhhh_version;
-                sendAlready(url, final_message);
-            }
-        });
-    }
-
-    function sendAlready(url, fin_message) {
-        // Send to database
-        $.post(url, fin_message)
-            .done(data => {
-                if (data) {
-                    const response = JSON.parse(data);
-                    showFlashMessage(response.status, response.message);
-                }
-            });
     }
 
     /**

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -34,11 +34,11 @@ import * as detailingFuncs from './modules/details/legacy';
     const ajaxSuccessHandlers = [
         new successHandlers.BountifulBeanstalkRoomTrackerAjaxHandler(logger, showFlashMessage),
         new successHandlers.GWHGolemAjaxHandler(logger, showFlashMessage),
-        new successHandlers.KingsGiveawayAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
-        new successHandlers.CheesyPipePartyAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
-        new successHandlers.SBFactoryAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
-        new successHandlers.SEHAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
-        new successHandlers.SpookyShuffleAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
+        new successHandlers.KingsGiveawayAjaxHandler(logger, submissionService),
+        new successHandlers.CheesyPipePartyAjaxHandler(logger, submissionService),
+        new successHandlers.SBFactoryAjaxHandler(logger, submissionService),
+        new successHandlers.SEHAjaxHandler(logger, submissionService),
+        new successHandlers.SpookyShuffleAjaxHandler(logger, submissionService),
         new successHandlers.TreasureMapHandler(logger, submissionService),
     ];
 

--- a/src/scripts/modules/ajax-handlers/kingsGiveaway.ts
+++ b/src/scripts/modules/ajax-handlers/kingsGiveaway.ts
@@ -1,4 +1,5 @@
 import {AjaxSuccessHandler} from "./ajaxSuccessHandler";
+import {SubmissionService} from "@scripts/services/submission.service";
 import {HgItem} from "@scripts/types/mhct";
 import {LoggerService} from "@scripts/util/logger";
 import {KingsGiveawayResponse} from "./kingsGiveaway.types";
@@ -13,11 +14,9 @@ export class KingsGiveawayAjaxHandler extends AjaxSuccessHandler {
      * @param submitConvertibleCallback delegate to submit convertibles to mhct
      */
     constructor(
-        private logger: LoggerService,
-        private submitConvertibleCallback: (convertible: HgItem, items: HgItem[]) => void) {
+        private readonly logger: LoggerService,
+        private readonly submissionService: SubmissionService) {
         super();
-        this.logger = logger;
-        this.submitConvertibleCallback = submitConvertibleCallback;
     }
 
     match(url: string): boolean {
@@ -103,9 +102,7 @@ export class KingsGiveawayAjaxHandler extends AjaxSuccessHandler {
         }
 
         this.logger.debug("Prizepack: ", {convertible, items});
-        this.submitConvertibleCallback(convertible, items);
-
-        return Promise.resolve();
+        await this.submissionService.submitEventConvertible(convertible, items);
     }
 
     async recordVault(responseJSON: KingsGiveawayResponse) {
@@ -137,9 +134,7 @@ export class KingsGiveawayAjaxHandler extends AjaxSuccessHandler {
             };
         });
 
-        this.submitConvertibleCallback(convertible, items);
-
-        return Promise.resolve();
+        await this.submissionService.submitEventConvertible(convertible, items);
     }
 
     /**

--- a/src/scripts/modules/ajax-handlers/sbFactory.CheesyPipeParty.ts
+++ b/src/scripts/modules/ajax-handlers/sbFactory.CheesyPipeParty.ts
@@ -4,6 +4,7 @@ import {LoggerService} from "@scripts/util/logger";
 import {AjaxSuccessHandler} from "./ajaxSuccessHandler";
 import {CheesyPipePartyGame, CheesyPipePartyResponse, cheesyPipePartyResponseSchema, Region} from "./sbFactory.types";
 import {CustomConvertibleIds} from "@scripts/util/constants";
+import {SubmissionService} from "@scripts/services/submission.service";
 
 export class CheesyPipePartyAjaxHandler extends AjaxSuccessHandler {
     /**
@@ -12,11 +13,9 @@ export class CheesyPipePartyAjaxHandler extends AjaxSuccessHandler {
      * @param submitConvertibleCallback delegate to submit convertibles to mhct
      */
     constructor(
-        private logger: LoggerService,
-        private submitConvertibleCallback: (convertible: HgItem, items: HgItem[]) => void) {
+        private readonly logger: LoggerService,
+        private readonly submissionService: SubmissionService) {
         super();
-        this.logger = logger;
-        this.submitConvertibleCallback = submitConvertibleCallback;
     }
 
     /**
@@ -38,16 +37,14 @@ export class CheesyPipePartyAjaxHandler extends AjaxSuccessHandler {
             return;
         }
 
-        this.recordCheesyPipeParty(responseJSON);
-
-        return Promise.resolve();
+        await this.recordCheesyPipeParty(responseJSON);
     }
 
     /**
      * Submit the Cheesy Pipe Party game results to MHCT
      * @param responseJSON
      */
-    recordCheesyPipeParty(responseJSON: CheesyPipePartyResponse) {
+    async recordCheesyPipeParty(responseJSON: CheesyPipePartyResponse) {
         const game = responseJSON.cheesy_pipe_party_game;
 
         const revealedPrizeTiles = this.getTiles(game).filter(tile => tile.has_prize && tile.is_prize_unlocked);
@@ -108,7 +105,8 @@ export class CheesyPipePartyAjaxHandler extends AjaxSuccessHandler {
         }
 
         this.logger.debug('CheesyPipePartyAjaxHandler submitting game board', {convertible, items});
-        this.submitConvertibleCallback(convertible, items);
+
+        await this.submissionService.submitEventConvertible(convertible, items);
     }
 
     /**

--- a/src/scripts/modules/ajax-handlers/sbFactory.ts
+++ b/src/scripts/modules/ajax-handlers/sbFactory.ts
@@ -1,3 +1,4 @@
+import {SubmissionService} from "@scripts/services/submission.service";
 import type {HgResponse} from "@scripts/types/hg";
 import type {HgItem} from "@scripts/types/mhct";
 import type {LoggerService} from "@scripts/util/logger";
@@ -12,11 +13,9 @@ export class SBFactoryAjaxHandler extends AjaxSuccessHandler {
      * @param submitConvertibleCallback delegate to submit convertibles to mhct
      */
     constructor(
-        private logger: LoggerService,
-        private submitConvertibleCallback: (convertible: HgItem, items: HgItem[]) => void) {
+        private readonly logger: LoggerService,
+        private readonly submissionService: SubmissionService) {
         super();
-        this.logger = logger;
-        this.submitConvertibleCallback = submitConvertibleCallback;
     }
 
     /**
@@ -33,16 +32,14 @@ export class SBFactoryAjaxHandler extends AjaxSuccessHandler {
             return;
         }
 
-        this.recordSnackPack(responseJSON);
-
-        return Promise.resolve();
+        await this.recordSnackPack(responseJSON);
     }
 
     /**
      * Record Birthday snack pack submissions as convertibles in MHCT
      * @param {import("@scripts/types/hg").HgResponse} responseJSON HitGrab ajax response from vending machine.
      */
-    recordSnackPack(responseJSON: VendingMachineReponse) {
+    async recordSnackPack(responseJSON: VendingMachineReponse) {
         const purchase = responseJSON.vending_machine_purchase;
 
         if (!purchase) {
@@ -109,7 +106,7 @@ export class SBFactoryAjaxHandler extends AjaxSuccessHandler {
         }
 
         this.logger.debug('SBFactoryAjaxHandler submitting snack pack', {convertible, items});
-        this.submitConvertibleCallback(convertible, items);
+        await this.submissionService.submitEventConvertible(convertible, items);
     }
 
     /**

--- a/src/scripts/modules/ajax-handlers/spookyShuffle.ts
+++ b/src/scripts/modules/ajax-handlers/spookyShuffle.ts
@@ -1,4 +1,5 @@
 import {AjaxSuccessHandler} from "./ajaxSuccessHandler";
+import {SubmissionService} from "@scripts/services/submission.service";
 import {HgItem} from "@scripts/types/mhct";
 import {LoggerService} from "@scripts/util/logger";
 import {SpookyShuffleResponse, spookyShuffleResponseSchema, TitleRange} from "./spookyShuffle.types";
@@ -13,11 +14,9 @@ export class SpookyShuffleAjaxHandler extends AjaxSuccessHandler {
      * @param submitConvertibleCallback delegate to submit convertibles to mhct
      */
     constructor(
-        private logger: LoggerService,
-        private submitConvertibleCallback: (convertible: HgItem, items: HgItem[]) => void) {
+        private readonly logger: LoggerService,
+        private readonly submissionService: SubmissionService) {
         super();
-        this.logger = logger;
-        this.submitConvertibleCallback = submitConvertibleCallback;
     }
 
     match(url: string): boolean {
@@ -104,7 +103,7 @@ export class SpookyShuffleAjaxHandler extends AjaxSuccessHandler {
         };
 
         this.logger.debug("Shuffle Board: ", {convertible, items: convertibleContent});
-        this.submitConvertibleCallback(convertible, convertibleContent);
+        await this.submissionService.submitEventConvertible(convertible, convertibleContent);
     }
 
     async fetchItemNameToIdMap(): Promise<Record<string, number>> {

--- a/src/scripts/modules/ajax-handlers/springEggHunt.ts
+++ b/src/scripts/modules/ajax-handlers/springEggHunt.ts
@@ -1,3 +1,4 @@
+import {SubmissionService} from "@scripts/services/submission.service";
 import type {HgResponse} from "@scripts/types/hg";
 import type {HgItem} from "@scripts/types/mhct";
 import type {LoggerService} from "@scripts/util/logger";
@@ -10,11 +11,9 @@ export class SEHAjaxHandler extends AjaxSuccessHandler {
      * @param submitConvertibleCallback delegate to submit convertibles to mhct
      */
     constructor(
-        private logger: LoggerService,
-        private submitConvertibleCallback: (convertible: HgItem, items: HgItem[]) => void) {
+        private readonly logger: LoggerService,
+        private readonly submissionService: SubmissionService) {
         super();
-        this.logger = logger;
-        this.submitConvertibleCallback = submitConvertibleCallback;
     }
 
     /**
@@ -27,16 +26,14 @@ export class SEHAjaxHandler extends AjaxSuccessHandler {
     }
 
     async execute(responseJSON: HgResponse): Promise<void> {
-        this.recordEgg(responseJSON as HgResponseWithEggContents);
-
-        return Promise.resolve();
+        await this.recordEgg(responseJSON as HgResponseWithEggContents);
     }
 
     /**
      * Record egg convertibles when opened from eggscavator
      * @param {import("@scripts/types/hg").HgResponse} responseJSON HitGrab ajax response.
      */
-    recordEgg(responseJSON: HgResponseWithEggContents) {
+    async recordEgg(responseJSON: HgResponseWithEggContents) {
         const purchase = responseJSON.egg_contents;
         const inventory = responseJSON.inventory;
 
@@ -92,7 +89,7 @@ export class SEHAjaxHandler extends AjaxSuccessHandler {
         }
 
         this.logger.debug('SEHAjaxHandler submitting egg convertible', {convertible, items});
-        this.submitConvertibleCallback(convertible, items);
+        await this.submissionService.submitEventConvertible(convertible, items);
     }
 }
 

--- a/src/scripts/services/submission.service.ts
+++ b/src/scripts/services/submission.service.ts
@@ -1,4 +1,4 @@
-import {HgItem, hgItemSchema, MhctResponseSchema} from "@scripts/types/mhct";
+import {HgItem, hgItemSchema, IntakeMessage, MhctResponseSchema} from "@scripts/types/mhct";
 import {UserSettings} from "@scripts/types/userSettings";
 import {LoggerService} from "@scripts/util/logger";
 import {getUnixTimestamp} from "@scripts/util/time";
@@ -30,12 +30,29 @@ export class SubmissionService {
         await this.submitConvertible(convertible, items);
     }
 
+    async submitHunt(hunt: IntakeMessage): Promise<void> {
+        if (this.userSettings['tracking-hunts'] === false) {
+            return;
+        }
+
+        // @ts-expect-error No index signature
+        await this.postData(this.environmentService.getMainIntakeUrl(), hunt);
+    }
+
     async submitItemConvertible(convertible: HgItem, items: HgItem[]): Promise<void> {
         if (this.userSettings['tracking-convertibles'] === false) {
             return;
         }
 
         await this.submitConvertible(convertible, items);
+    }
+
+    async submitRejection(rejection: Record<string, unknown>): Promise<void> {
+        if (this.userSettings['tracking-hunts'] === false) {
+            return;
+        }
+
+        await this.postData(this.environmentService.getRejectionIntakeUrl(), rejection);
     }
 
     async submitRelicHunterHint(hint: string): Promise<void> {

--- a/tests/scripts/modules/ajax-handlers/sbFactory.CheesyPipeParty.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/sbFactory.CheesyPipeParty.spec.ts
@@ -1,15 +1,14 @@
 import {CheesyPipePartyAjaxHandler} from "@scripts/modules/ajax-handlers";
 import {CheesyPipePartyGame, CheesyPipePartyResponse} from "@scripts/modules/ajax-handlers/sbFactory.types";
+import {SubmissionService} from "@scripts/services/submission.service";
 import {InventoryItem} from "@scripts/types/hg";
-import {HgItem} from "@scripts/types/mhct";
-import {ConsoleLogger} from '@scripts/util/logger';
+import {LoggerService} from '@scripts/util/logger';
 import {HgResponseBuilder} from "@tests/utility/builders";
+import {mock} from "jest-mock-extended";
 
-jest.mock('@scripts/util/logger');
-
-const logger = new ConsoleLogger();
-const submitConvertibleCallback = jest.fn() as jest.MockedFunction<(convertible: HgItem, items: HgItem[]) => void>;
-const handler = new CheesyPipePartyAjaxHandler(logger, submitConvertibleCallback);
+const logger = mock<LoggerService>();
+const submissionService = mock<SubmissionService>();
+const handler = new CheesyPipePartyAjaxHandler(logger, submissionService);
 
 const sbfactory_url = "mousehuntgame.com/managers/ajax/events/cheesy_pipe_party.php";
 
@@ -54,7 +53,7 @@ describe("CheesyPipePartyAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.warn).toHaveBeenCalledWith('Unexpected Cheesy Pipe Party response object.', expect.anything());
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('logs if pipe party response is not complete', async () => {
@@ -64,7 +63,7 @@ describe("CheesyPipePartyAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.debug).toHaveBeenCalledWith('Cheesy Pipe Party game is not complete.');
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('submits board with one prize', async () => {
@@ -87,7 +86,7 @@ describe("CheesyPipePartyAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toHaveBeenCalledWith(
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledWith(
                 expect.objectContaining(expectedConvertible),
                 expect.objectContaining(expectedItems)
             );
@@ -114,7 +113,7 @@ describe("CheesyPipePartyAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toHaveBeenCalledWith(
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledWith(
                 expect.objectContaining(expectedConvertible),
                 expect.objectContaining(expectedItems)
             );
@@ -131,7 +130,7 @@ describe("CheesyPipePartyAjaxHandler", () => {
                 revealedPrizeTiles: expect.arrayContaining([expect.anything()]),
                 expectedPrizes: 2,
             }));
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('logs when region is not found', async () => {
@@ -143,7 +142,7 @@ describe("CheesyPipePartyAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.warn).toHaveBeenCalledWith('Unexpected Cheesy Pipe Party response object.', expect.anything());
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/tests/scripts/modules/ajax-handlers/sbFactory.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/sbFactory.spec.ts
@@ -1,15 +1,14 @@
 import {SBFactoryAjaxHandler} from "@scripts/modules/ajax-handlers";
 import {VendingMachinePurchase, VendingMachineReponse} from "@scripts/modules/ajax-handlers/sbFactory.types";
+import {SubmissionService} from "@scripts/services/submission.service";
 import {InventoryItem} from "@scripts/types/hg";
-import {HgItem} from "@scripts/types/mhct";
-import {ConsoleLogger} from '@scripts/util/logger';
+import {LoggerService} from '@scripts/util/logger';
 import {HgResponseBuilder} from "@tests/utility/builders";
+import {mock} from "jest-mock-extended";
 
-jest.mock('@scripts/util/logger');
-
-const logger = new ConsoleLogger();
-const submitConvertibleCallback = jest.fn() as jest.MockedFunction<(convertible: HgItem, items: HgItem[]) => void>;
-const handler = new SBFactoryAjaxHandler(logger, submitConvertibleCallback);
+const logger = mock<LoggerService>();
+const submissionService = mock<SubmissionService>();
+const handler = new SBFactoryAjaxHandler(logger, submissionService);
 
 const sbfactory_url = "mousehuntgame.com/managers/ajax/events/birthday_factory.php";
 
@@ -39,7 +38,7 @@ describe("SBFactoryAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.warn).toHaveBeenCalledWith('Unexpected vending machine response object.', expect.anything());
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('submits expected response one', async () => {
@@ -78,7 +77,7 @@ describe("SBFactoryAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toHaveBeenCalledWith(
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledWith(
                 expect.objectContaining(expectedConvertible),
                 expect.objectContaining(expectedItems)
             );
@@ -120,7 +119,7 @@ describe("SBFactoryAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toHaveBeenCalledWith(
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledWith(
                 expect.objectContaining(expectedConvertible),
                 expect.objectContaining(expectedItems)
             );

--- a/tests/scripts/modules/ajax-handlers/spookyShuffle.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/spookyShuffle.spec.ts
@@ -1,18 +1,17 @@
 import {SpookyShuffleAjaxHandler} from "@scripts/modules/ajax-handlers";
 import {SpookyShuffleResponse, SpookyShuffleStatus} from "@scripts/modules/ajax-handlers/spookyShuffle.types";
-import {HgItem} from "@scripts/types/mhct";
+import {SubmissionService} from "@scripts/services/submission.service";
+import {LoggerService} from '@scripts/util/logger';
+import {CustomConvertibleIds} from "@scripts/util/constants";
+import {getItemsByClass} from "@scripts/util/hgFunctions";
+import {HgResponseBuilder} from "@tests/utility/builders";
+import {mock} from "jest-mock-extended";
 
-jest.mock('@scripts/util/logger');
 jest.mock('@scripts/util/hgFunctions');
 
-import {ConsoleLogger} from '@scripts/util/logger';
-import {getItemsByClass} from "@scripts/util/hgFunctions";
-import {CustomConvertibleIds} from "@scripts/util/constants";
-import {HgResponseBuilder} from "@tests/utility/builders";
-
-const logger = new ConsoleLogger();
-const submitConvertibleCallback = jest.fn() as jest.MockedFunction<(convertible: HgItem, items: HgItem[]) => void>;
-const handler = new SpookyShuffleAjaxHandler(logger, submitConvertibleCallback);
+const logger = mock<LoggerService>();
+const submissionService = mock<SubmissionService>();
+const handler = new SpookyShuffleAjaxHandler(logger, submissionService);
 const mockedGetItemsByClass = jest.mocked(getItemsByClass);
 
 const spookyShuffle_url = "mousehuntgame.com/managers/ajax/events/spooky_shuffle.php";
@@ -45,7 +44,7 @@ describe("SpookyShuffleAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.warn).toHaveBeenCalledWith('Unexpected spooky shuffle response object.', expect.anything());
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('debug logs if response is an incomplete game', async () => {
@@ -64,7 +63,7 @@ describe("SpookyShuffleAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.debug).toHaveBeenCalledWith('Spooky Shuffle board is not complete yet.');
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('debug logs if response is an complete game but no testing pair', async () => {
@@ -84,7 +83,7 @@ describe("SpookyShuffleAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.debug).toHaveBeenCalledWith('Spooky Shuffle board is not complete yet.');
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('submits regular novice board', async () => {
@@ -137,7 +136,7 @@ describe("SpookyShuffleAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toHaveBeenCalledWith(
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledWith(
                 expect.objectContaining(expectedConvertible),
                 expect.objectContaining(expectedItems)
             );
@@ -206,7 +205,7 @@ describe("SpookyShuffleAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toHaveBeenCalledWith(
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledWith(
                 expect.objectContaining(expectedConvertible),
                 expect.objectContaining(expectedItems)
             );
@@ -249,7 +248,7 @@ describe("SpookyShuffleAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.warn).toHaveBeenCalledWith(`Item 'Test Item' wasn't found in item map. Check its classification type`);
-            expect(submitConvertibleCallback).not.toHaveBeenCalled();
+            expect(submissionService.submitEventConvertible).not.toHaveBeenCalled();
         });
 
     });

--- a/tests/scripts/modules/ajax-handlers/springEggHunt.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/springEggHunt.spec.ts
@@ -1,13 +1,12 @@
 import {SEHAjaxHandler} from "@scripts/modules/ajax-handlers";
+import {SubmissionService} from "@scripts/services/submission.service";
 import {HgResponse} from "@scripts/types/hg";
-import {HgItem} from "@scripts/types/mhct";
+import {LoggerService} from '@scripts/util/logger';
+import {mock} from "jest-mock-extended";
 
-jest.mock('@scripts/util/logger');
-import {ConsoleLogger} from '@scripts/util/logger';
-
-const logger = new ConsoleLogger();
-const submitConvertibleCallback = jest.fn() as jest.MockedFunction<(convertible: HgItem, items: HgItem[]) => void>;
-const handler = new SEHAjaxHandler(logger, submitConvertibleCallback);
+const logger = mock<LoggerService>();
+const submissionService = mock<SubmissionService>();
+const handler = new SEHAjaxHandler(logger, submissionService);
 
 const sbfactory_url = "mousehuntgame.com/managers/ajax/events/spring_hunt.php";
 
@@ -31,7 +30,7 @@ describe("SEHAjaxHandler", () => {
             await handler.execute({} as unknown as HgResponse);
 
             expect(logger.debug).toBeCalledWith('Skipping SEH egg submission as this isn\'t an egg convertible');
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('warns if response is unexpected', async () => {
@@ -41,7 +40,7 @@ describe("SEHAjaxHandler", () => {
             await handler.execute(response);
 
             expect(logger.warn).toBeCalledWith('Unable to parse SEH response', {responseJSON: response});
-            expect(submitConvertibleCallback).toHaveBeenCalledTimes(0);
+            expect(submissionService.submitEventConvertible).toHaveBeenCalledTimes(0);
         });
 
         it('submits expected response one', async () => {
@@ -72,7 +71,7 @@ describe("SEHAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toBeCalledWith(
+            expect(submissionService.submitEventConvertible).toBeCalledWith(
                 expectedConvertible,
                 expectedItems
             );
@@ -106,7 +105,7 @@ describe("SEHAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toBeCalledWith(
+            expect(submissionService.submitEventConvertible).toBeCalledWith(
                 expectedConvertible,
                 expectedItems
             );
@@ -130,7 +129,7 @@ describe("SEHAjaxHandler", () => {
                 },
             ];
 
-            expect(submitConvertibleCallback).toBeCalledWith(
+            expect(submissionService.submitEventConvertible).toBeCalledWith(
                 expectedConvertible,
                 expectedItems
             );


### PR DESCRIPTION
- **Refactor ajax handlers to use submission service**
- **Add hunt and rejection to submission service**

So my other PR wasn't too much, ajax handlers now use submission service directly instead of bound method.
