### PR TITLE
Validated Ajax Handlers w/ Treasure Map Example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "html-webpack-plugin": "^5.6.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-mock-extended": "^3.0.7",
         "mergician": "^2.0.2",
         "ts-jest": "^29.3.1",
         "ts-loader": "^9.5.1",
@@ -6825,6 +6826,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.7.tgz",
+      "integrity": "sha512-7lsKdLFcW9B9l5NzZ66S/yTQ9k8rFtnwYdCNuRU/81fqDWicNDVhitTSPnrGmNeNm0xyw0JHexEOShrIKRCIRQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-essentials": "^10.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -9474,6 +9488,20 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "html-webpack-plugin": "^5.6.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-mock-extended": "^3.0.7",
     "mergician": "^2.0.2",
     "ts-jest": "^29.3.1",
     "ts-loader": "^9.5.1",

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -39,6 +39,7 @@ import * as detailingFuncs from './modules/details/legacy';
         new successHandlers.SBFactoryAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
         new successHandlers.SEHAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
         new successHandlers.SpookyShuffleAjaxHandler(logger, (...args) => submissionService.submitEventConvertible(...args)),
+        new successHandlers.TreasureMapHandler(logger, submissionService),
     ];
 
     async function main() {
@@ -365,11 +366,7 @@ import * as detailingFuncs from './modules/details/legacy';
 
         $(document).ajaxSuccess((event, xhr, ajaxOptions) => {
             const url = ajaxOptions.url;
-            if (url.includes("mousehuntgame.com/managers/ajax/users/treasuremap_v2.php")) {
-                if (userSettings['tracking-convertibles']) {
-                    recordMap(xhr);
-                }
-            } else if (url.includes("mousehuntgame.com/managers/ajax/users/useconvertible.php")) {
+            if (url.includes("mousehuntgame.com/managers/ajax/users/useconvertible.php")) {
                 // Calls submitItemConvertible which checks if tracking-convertibles is on
                 recordConvertible(xhr);
             } else if (url.includes("mousehuntgame.com/managers/ajax/pages/page.php")) {
@@ -467,32 +464,6 @@ import * as detailingFuncs from './modules/details/legacy';
             "mhct_crown_update": 1,
             "crowns": payload,
         }, window.origin);
-    }
-
-    // Record map mice
-    function recordMap(xhr) {
-        const resp = xhr.responseJSON;
-        if (resp.treasure_map_inventory?.relic_hunter_hint) {
-            sendMessageToServer(environmentService.getRhIntakeUrl(), {
-                hint: resp.treasure_map_inventory.relic_hunter_hint,
-            });
-        }
-
-        const {map_id, name} = resp.treasure_map ?? {};
-        if (!map_id || !name) {
-            return;
-        }
-        const map = {
-            mice: getMapMice(resp),
-            id: map_id,
-            name: name.replace(/ treasure/i, '')
-                .replace(/rare /i, '')
-                .replace(/common /i, '')
-                .replace(/Ardouous/i, 'Arduous'),
-        };
-
-        // Send to database
-        sendMessageToServer(environmentService.getMainIntakeUrl(), map);
     }
 
     /**

--- a/src/scripts/modules/ajax-handlers/ajaxSuccessHandler.ts
+++ b/src/scripts/modules/ajax-handlers/ajaxSuccessHandler.ts
@@ -1,6 +1,31 @@
 import type {HgResponse} from "@scripts/types/hg";
+import {LoggerService} from "@scripts/util/logger";
+import {z} from "zod";
 
 export abstract class AjaxSuccessHandler {
     abstract match(url: string): boolean;
     abstract execute(responseJSON: HgResponse): Promise<void>;
+}
+
+export abstract class ValidatedAjaxSuccessHandler extends AjaxSuccessHandler {
+    abstract readonly schema: z.ZodSchema;
+
+    constructor(private readonly logger: LoggerService) {
+        super();
+    }
+
+    async execute(responseJSON: HgResponse): Promise<void> {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const data = await this.schema.parseAsync(responseJSON);
+            await this.validatedExecute(data);
+        } catch (e) {
+            if (e instanceof z.ZodError) {
+                this.logger.warn(`Couldn't validate JSON response`, e);
+            }
+            throw e;
+        }
+    }
+
+    protected abstract validatedExecute(data: z.infer<typeof this.schema>): Promise<void>;
 }

--- a/src/scripts/modules/ajax-handlers/index.ts
+++ b/src/scripts/modules/ajax-handlers/index.ts
@@ -4,4 +4,5 @@ export * from "./kingsGiveaway";
 export * from "./springEggHunt";
 export * from "./sbFactory";
 export * from "./sbFactory.CheesyPipeParty";
+export * from "./treasureMap";
 export * from "./spookyShuffle";

--- a/src/scripts/modules/ajax-handlers/treasureMap.ts
+++ b/src/scripts/modules/ajax-handlers/treasureMap.ts
@@ -1,0 +1,72 @@
+import {hgResponseSchema} from "@scripts/types/hg";
+import {ValidatedAjaxSuccessHandler} from "./ajaxSuccessHandler";
+import {z} from "zod";
+import {SubmissionService} from "@scripts/services/submission.service";
+import {LoggerService} from "@scripts/util/logger";
+
+
+export class TreasureMapHandler extends ValidatedAjaxSuccessHandler {
+
+    constructor(logger: LoggerService,
+        private readonly submissionService: SubmissionService) {
+        super(logger);
+    }
+
+    schema = hgResponseSchema.extend({
+        treasure_map_inventory: z.object({
+            relic_hunter_hint: z.string(),
+        }).optional(),
+        treasure_map: z.object({
+            name: z.string().transform((name) => name
+                .replace(/ treasure/i, '')
+                .replace(/rare /i, '')
+                .replace(/common /i, '')
+                .replace(/Ardouous/i, 'Arduous'),
+            ),
+            map_id: z.coerce.number(),
+            goals: z.object({
+                mouse: z.array(z.object({
+                    unique_id: z.coerce.number(),
+                    name: z.string(),
+                })),
+            }),
+        }).optional(),
+    });
+
+    match(url: string): boolean {
+        return url.includes("mousehuntgame.com/managers/ajax/users/treasuremap_v2.php");
+    }
+
+    protected async validatedExecute(data: z.infer<typeof this.schema>): Promise<void> {
+
+        const hint = data.treasure_map_inventory?.relic_hunter_hint;
+        if (hint) {
+            await this.submissionService.submitRelicHunterHint(hint);
+        }
+
+        const treasureMap = data.treasure_map;
+        if (!treasureMap) {
+            return;
+        }
+
+        // we don't support anything but mice related goals
+        if (treasureMap.goals.mouse.length === 0) {
+            return;
+        }
+
+        // create record of mice name by unique_id
+        const mice = treasureMap.goals.mouse.reduce((acc, mouse) => {
+            acc[mouse.unique_id] = mouse.name;
+            return acc;
+        }, {} as Record<number, string>);
+
+        const map = {
+            mice,
+            id: treasureMap.map_id,
+            name: treasureMap.name,
+        };
+
+        await this.submissionService.submitTreasureMap(map);
+    }
+
+}

--- a/src/scripts/types/hg/treasureMap.ts
+++ b/src/scripts/types/hg/treasureMap.ts
@@ -1,0 +1,24 @@
+import {z} from "zod";
+
+export const treasureMapSchema = z.object({
+    map_id: z.coerce.number(),
+    name: z.string(),
+    goals: z.object({
+        mouse: z.array(z.object({
+            unique_id: z.coerce.number(),
+            name: z.string(),
+        })),
+        item: z.array(z.object({
+            unique_id: z.coerce.number(),
+            name: z.string(),
+        })),
+    }),
+});
+
+export type TreasureMap = z.infer<typeof treasureMapSchema>;
+
+export const treasureMapInventorySchema = z.object({
+    relic_hunter_hint: z.string().optional(),
+});
+
+export type TreasureMapInventory = z.infer<typeof treasureMapInventorySchema>;

--- a/tests/scripts/modules/ajax-handlers/treasureMap.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/treasureMap.spec.ts
@@ -1,0 +1,221 @@
+import {TreasureMapHandler} from "@scripts/modules/ajax-handlers/treasureMap";
+import {SubmissionService} from "@scripts/services/submission.service";
+import {TreasureMap, TreasureMapInventory} from "@scripts/types/hg/treasureMap";
+import {HgResponse} from "@scripts/types/hg";
+import {HgResponseBuilder} from "@tests/utility/builders";
+import {LoggerService} from "@scripts/util/logger";
+import {mock} from "jest-mock-extended";
+
+class TreasureMapResponseBuilder extends HgResponseBuilder {
+    treasure_map_inventory?: {
+        relic_hunter_hint?: string;
+    };
+    treasure_map?: TreasureMap;
+
+    withRelicHunterHint(hint: string): this {
+        this.treasure_map_inventory = {
+            relic_hunter_hint: hint
+        };
+
+        return this;
+    }
+
+    withTreasureMap(map: {
+        name: string;
+        map_id: number;
+        goals: {
+            mouse: {
+                unique_id: number;
+                name: string;
+            }[],
+            item: {
+                unique_id: number;
+                name: string;
+            }[],
+        };
+    }): this {
+        this.treasure_map = map;
+
+        return this;
+    }
+
+    build(): HgResponse & {
+        treasure_map_inventory?: TreasureMapInventory;
+        treasure_map?: TreasureMap;
+        } {
+        return {
+            ...super.build(),
+            treasure_map_inventory: this.treasure_map_inventory,
+            treasure_map: this.treasure_map,
+        };
+    }
+}
+
+const logger = mock<LoggerService>();
+const submissionService = mock<SubmissionService>();
+
+describe("TreasureMapHandler", () => {
+    let responseBuilder: TreasureMapResponseBuilder;
+    let handler: TreasureMapHandler;
+
+    const treasureMapUrl = "mousehuntgame.com/managers/ajax/users/treasuremap_v2.php";
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        responseBuilder = new TreasureMapResponseBuilder();
+        handler = new TreasureMapHandler(logger, submissionService);
+    });
+
+    describe("match", () => {
+        it('returns true when URL contains treasuremap_v2.php', () => {
+            expect(handler.match(treasureMapUrl)).toBe(true);
+        });
+
+        it('returns false for unrelated URLs', () => {
+            expect(handler.match("mousehuntgame.com/managers/ajax/events/kings_giveaway.php")).toBe(false);
+        });
+    });
+
+    describe("validatedExecute", () => {
+        it('submits relic hunter hint when present', async () => {
+            const response = responseBuilder
+                .withRelicHunterHint("The Relic Hunter can be found in Gnawnia.")
+                .build();
+
+            await handler.execute(response);
+
+            expect(submissionService.submitRelicHunterHint).toHaveBeenCalledWith(
+                "The Relic Hunter can be found in Gnawnia."
+            );
+            expect(submissionService.submitTreasureMap).not.toHaveBeenCalled();
+        });
+
+        it('submits treasure map data when map has mice', async () => {
+            const response = responseBuilder
+                .withTreasureMap({
+                    name: "Rare Test Treasure Map",
+                    map_id: 12345,
+                    goals: {
+                        mouse: [
+                            {unique_id: 101, name: "Test Mouse"},
+                            {unique_id: 102, name: "Another Mouse"}
+                        ],
+                        item: []
+                    }
+                })
+                .build();
+
+            await handler.execute(response);
+
+            expect(submissionService.submitTreasureMap).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    mice: {
+                        101: "Test Mouse",
+                        102: "Another Mouse"
+                    },
+                    id: 12345,
+                    name: "Test Map"
+                })
+            );
+            expect(submissionService.submitRelicHunterHint).not.toHaveBeenCalled();
+        });
+
+        it('properly transforms map names', async () => {
+            const response = responseBuilder.build();
+            response.treasure_map = {
+                name: "Rare Ardouous Treasure Map",
+                map_id: 12345,
+                goals: {
+                    mouse: [
+                        {unique_id: 101, name: "Test Mouse"}
+                    ],
+                    item: []
+                }
+            };
+
+            await handler.execute(response);
+
+            expect(submissionService.submitTreasureMap).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: "Arduous Map"
+                })
+            );
+        });
+
+        it('does not submit map when no mice are present', async () => {
+            const response = responseBuilder.build();
+            response.treasure_map = {
+                name: "Common Empty Treasure Map",
+                map_id: 12345,
+                goals: {
+                    mouse: [],
+                    item: []
+                }
+            };
+
+            await handler.execute(response);
+
+            expect(submissionService.submitTreasureMap).not.toHaveBeenCalled();
+        });
+
+        it('does not submit map when items are present', async () => {
+            const response = responseBuilder.build();
+            response.treasure_map = {
+                name: "Common Empty Scavenger Hunt",
+                map_id: 12345,
+                goals: {
+                    mouse: [],
+                    item: [
+                        {unique_id: 201, name: "Test Item"},
+                        {unique_id: 202, name: "Another Item"}
+                    ]
+                }
+            };
+
+            await handler.execute(response);
+
+            expect(submissionService.submitTreasureMap).not.toHaveBeenCalled();
+        });
+
+        it('handles both relic hunter hint and treasure map', async () => {
+            const response = responseBuilder.build();
+            response.treasure_map_inventory = {
+                relic_hunter_hint: "The Relic Hunter can be found in Burroughs."
+            };
+            response.treasure_map = {
+                name: "Rare Mighty Treasure Map",
+                map_id: 67890,
+                goals: {
+                    mouse: [
+                        {unique_id: 201, name: "Mighty Mouse"}
+                    ],
+                    item: []
+                }
+            };
+
+            await handler.execute(response);
+
+            expect(submissionService.submitRelicHunterHint).toHaveBeenCalledWith(
+                "The Relic Hunter can be found in Burroughs."
+            );
+            expect(submissionService.submitTreasureMap).toHaveBeenCalledWith({
+                mice: {
+                    201: "Mighty Mouse"
+                },
+                id: 67890,
+                name: "Mighty Map"
+            });
+        });
+
+        it('does nothing when neither hint nor map is present', async () => {
+            const response = responseBuilder.build();
+
+            await handler.execute(response);
+
+            expect(submissionService.submitRelicHunterHint).not.toHaveBeenCalled();
+            expect(submissionService.submitTreasureMap).not.toHaveBeenCalled();
+        });
+    });
+
+});


### PR DESCRIPTION
- **Add new base class for zod validated ajax success handlers**
- **Convert recordMap to new validated ajax success handler**

`AjaxSuccessHandlers` can now inherit from `ValidatedAjaxSuccessHandler` and define a Zod schema in a field. That schema will be used and if it matches will be pass down to a `validatedExecute` method. The data is guaranteed to match the defined schema! No more needing to assume data type.

This will eventually lead to the removal of event date flags!

