### PR TITLE
Add abstraction for mouse.rip API. Fix KGA handling.

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,6 +2,7 @@
 import {IntakeRejectionEngine} from "./hunt-filter/engine";
 import {ConsoleLogger, LogLevel} from './util/logger';
 import {EnvironmentService} from "./services/environment.service";
+import {MouseRipApiService} from "./services/mouserip-api.service";
 import {SubmissionService} from "./services/submission.service";
 import {ApiService} from "./services/api.service";
 import {hgResponseSchema} from "./types/hg";
@@ -30,10 +31,11 @@ import * as detailingFuncs from './modules/details/legacy';
         }),
         showFlashMessage
     );
+    const mouseRipApiService = new MouseRipApiService(logger, apiService);
     const ajaxSuccessHandlers = [
         new successHandlers.BountifulBeanstalkRoomTrackerAjaxHandler(logger, showFlashMessage),
         new successHandlers.GWHGolemAjaxHandler(logger, showFlashMessage),
-        new successHandlers.KingsGiveawayAjaxHandler(logger, submissionService, apiService),
+        new successHandlers.KingsGiveawayAjaxHandler(logger, submissionService, mouseRipApiService),
         new successHandlers.CheesyPipePartyAjaxHandler(logger, submissionService),
         new successHandlers.SBFactoryAjaxHandler(logger, submissionService),
         new successHandlers.SEHAjaxHandler(logger, submissionService),

--- a/src/scripts/services/api.service.ts
+++ b/src/scripts/services/api.service.ts
@@ -1,16 +1,59 @@
-import {param} from '@scripts/util/param';
+import {param} from "@scripts/util/param";
 
 export class ApiService {
-    async send(method: 'GET' | 'POST', url: string, body: unknown): Promise<Response> {
-        return await fetch(new Request(
-            url,
-            {
-                method: method,
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: param(body),
+    /**
+     * Sends an HTTP request to the specified URL.
+     *
+     * @param method - The HTTP method to use ('GET' or 'POST')
+     * @param url - The target URL for the request
+     * @param body - The request body data (will be processed according to its type)
+     * @param hasResponse - Indicates whether a response body is expected
+     * @param alterHeaders - Optional callback to modify request headers before sending
+     *
+     * @returns A Promise resolving to the response data (JSON or text based on Content-Type)
+     * or rejecting with an error if the request fails
+     *
+     * @throws Error if the response status is not 200 or 204
+     *
+     * @remarks
+     * - For string bodies, Content-Type is set to application/json
+     * - For object bodies, they are converted to URL-encoded format
+     * - If hasResponse is true, sets Accept header to application/json
+     */
+    async send(method: 'GET' | 'POST', url: string, body: unknown, hasResponse: boolean, alterHeaders?: (headers: Headers) => void): Promise<unknown> {
+        const headers = new Headers();
+        if (hasResponse) {
+            headers.append('Accept', 'application/json');
+        }
+
+        if (alterHeaders != null) {
+            alterHeaders(headers);
+        }
+
+        let requestBody: BodyInit | null | undefined = null;
+        if (body != null) {
+            if (typeof body === 'string') {
+                headers.set('Content-Type', 'application/json; charset=utf-8');
+                requestBody = body;
+            } else if (typeof body === 'object') {
+                headers.set('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8');
+                requestBody = param(body);
             }
-        ));
+        }
+
+        const requestInit: RequestInit = {
+            method: method,
+            headers: headers,
+            body: requestBody,
+        };
+
+        const response = await fetch(new Request(url, requestInit));
+        const responseType = response.headers.get('Content-Type');
+        const responseIsJson = responseType?.includes('application/json');
+        if (hasResponse && response.status === 200) {
+            return responseIsJson ? await response.json() : await response.text();
+        } else if (response.status !== 200 && response.status !== 204) {
+            return Promise.reject(new Error(`Request failed with status ${response.status}: ${response.statusText}`));
+        }
     }
 }

--- a/src/scripts/services/mouserip-api.service.ts
+++ b/src/scripts/services/mouserip-api.service.ts
@@ -1,0 +1,26 @@
+import {LoggerService} from "@scripts/util/logger";
+import {ApiService} from "./api.service";
+import {z} from "zod";
+
+export class MouseRipApiService {
+    constructor(private readonly logger: LoggerService,
+        private readonly apiService: ApiService) {}
+
+    async getAllItems(): Promise<MouseRipItem[]> {
+        const response = await this.apiService.send('GET', 'https://api.mouse.rip/items', null, true, (headers) => this.alterHeaders(headers));
+
+        return mouseRipItemSchema.array().parse(response);
+    }
+
+    private alterHeaders(headers: Headers): void {
+        headers.set('X-Requested-With', 'MHCT');
+    }
+}
+
+export const mouseRipItemSchema = z.object({
+    id: z.number(),
+    type: z.string(),
+    name: z.string(),
+});
+
+export type MouseRipItem = z.infer<typeof mouseRipItemSchema>;

--- a/tests/scripts/modules/ajax-handlers/kingsGiveaway.spec.ts
+++ b/tests/scripts/modules/ajax-handlers/kingsGiveaway.spec.ts
@@ -1,5 +1,5 @@
 import {KingsGiveawayAjaxHandler} from "@scripts/modules/ajax-handlers/kingsGiveaway";
-import {ApiService} from "@scripts/services/api.service";
+import {MouseRipApiService} from "@scripts/services/mouserip-api.service";
 import {SubmissionService} from "@scripts/services/submission.service";
 import {CustomConvertibleIds} from "@scripts/util/constants";
 import {LoggerService} from "@scripts/util/logger";
@@ -8,7 +8,7 @@ import {mock} from "jest-mock-extended";
 
 const logger = mock<LoggerService>();
 const submissionService = mock<SubmissionService>();
-const apiService = mock<ApiService>();
+const mouseRipApiService = mock<MouseRipApiService>();
 
 const kga_url = "mousehuntgame.com/managers/ajax/events/kings_giveaway.php";
 
@@ -18,32 +18,19 @@ describe("KingsGiveawayAjaxHandler", () => {
 
     // Mouse RIP item mock
     const knownVaultItems = [
-        //{type: 'extreme_regal_trinket', item_id: 2542},
-        {type: 'prize_credit_stat_item', item_id: 420},
-        {type: 'rainbow_scroll_case_convertible', item_id: 1974},
-        {type: 'rainbow_luck_trinket', item_id: 1692},
+        //{type: 'extreme_regal_trinket', id: 2542},
+        {type: 'prize_credit_stat_item', name: 'King\'s Credit', id: 420},
+        {type: 'rainbow_scroll_case_convertible', name: 'Rainbow Scroll Case', id: 1974},
+        {type: 'rainbow_luck_trinket', name: 'Rainbow Luck Charm', id: 1692},
     ];
 
     beforeEach(() => {
         jest.clearAllMocks();
 
-        apiService.send.mockImplementation((method, url, body) => {
-
-            if (url === "https://api.mouse.rip/items")
-            {
-                return Promise.resolve({
-                    ok: true,
-                    json: () => Promise.resolve(knownVaultItems)
-                } as unknown as Promise<Response>);
-            }
-
-            return Promise.resolve({
-                ok: false
-            }) as unknown as Promise<Response>;
-        });
+        mouseRipApiService.getAllItems.mockResolvedValue(knownVaultItems);
 
         responseBuilder = new HgResponseBuilder();
-        handler = new KingsGiveawayAjaxHandler(logger, submissionService, apiService);
+        handler = new KingsGiveawayAjaxHandler(logger, submissionService, mouseRipApiService);
     });
 
     describe("match", () => {

--- a/tests/scripts/services/submisssion.service.spec.ts
+++ b/tests/scripts/services/submisssion.service.spec.ts
@@ -51,15 +51,9 @@ describe('SubmissionService', () => {
         mockApiService = {
             send: jest.fn().mockImplementation((method, url, body) => {
                 if (url === 'uuid-url') {
-                    return Promise.resolve({
-                        ok: true,
-                        text: () => Promise.resolve('test-uuid')
-                    }) as unknown as Promise<Response>;
+                    return Promise.resolve('test-uuid');
                 } else {
-                    return Promise.resolve({
-                        ok: true,
-                        json: () => Promise.resolve({success: true, message: 'Success', status: 'success'})
-                    }) as unknown as Promise<Response>;
+                    return Promise.resolve({success: true, message: 'Success', status: 'success'});
                 }
             })
         } as unknown as jest.Mocked<ApiService>;
@@ -114,7 +108,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
 
             // Verify second API call (submission)
@@ -129,7 +124,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp,
-                })
+                }),
+                true
             );
 
             expect(mockShowFlashMessage).toHaveBeenCalledWith('Success', 'success');
@@ -210,7 +206,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
         });
 
@@ -256,7 +253,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
         });
 
@@ -304,7 +302,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
 
             // Verify second API call (submission)
@@ -318,7 +317,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
 
             expect(mockShowFlashMessage).toHaveBeenCalledWith('Success', 'success');
@@ -375,7 +375,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
 
             // Verify second API call (submission)
@@ -389,7 +390,8 @@ describe('SubmissionService', () => {
                     hunter_id_hash: mockHunterInfo.hunter_id_hash,
                     extension_version: mockHunterInfo.mhhh_version,
                     entry_timestamp: testTimestamp
-                })
+                }),
+                true
             );
 
             expect(mockShowFlashMessage).toHaveBeenCalledWith('Success', 'success');
@@ -424,20 +426,16 @@ describe('SubmissionService', () => {
         it('logs error when UUID request fails', async () => {
             mockApiService.send.mockImplementation((method, url, body) => {
                 if (url === 'uuid-url') {
-                    return Promise.resolve({
-                        ok: false,
-                        status: 500,
-                        statusText: 'Server Error'
-                    }) as unknown as Promise<Response>;
+                    return Promise.reject(new Error("UUID request failed"));
                 }
-                return Promise.resolve({}) as unknown as Promise<Response>;
+                return Promise.resolve({});
             });
 
             await service.submitEventConvertible(convertible, items);
 
             expect(mockLogger.error).toHaveBeenCalledWith(
-                "Failed to get UUID",
-                expect.objectContaining({ok: false})
+                "An error occurred while submitting to MHCT",
+                new Error("UUID request failed")
             );
             expect(mockApiService.send).toHaveBeenCalledTimes(1);
         });


### PR DESCRIPTION
Instead of using ApiService directly, it's smarter to create a wrapper for each website we reach out to. Exactly how SubmissionService uses ApiService and is exclusively for mhct.win.

KGA handling had two problems: one was accidentally sending a body on a GET request which isn't allowed in browsers and a zod related error was that the item property `item_id` was actually just `id`. 

I've fixed the docs on api.mouse.rip to reflect what the api actually returns.