### PR TITLE
Fix expected number, got NaN map error.

### DIFF
--- a/src/scripts/types/hg/quests/relicHunter.ts
+++ b/src/scripts/types/hg/quests/relicHunter.ts
@@ -2,8 +2,7 @@ import z from "zod";
 
 const mapSchema = z.object({
     name: z.string(),
-    is_complete: z.literal(true).or(z.null()),
-    remaining: z.coerce.number(),
+    is_complete: z.literal(true).or(z.null())
 });
 
 export const questRelicHunterSchema = z.object({


### PR DESCRIPTION
Interacting with my map gives me a console warning:
```
Unexpected response type received ✖ Invalid input: expected number, received NaN
  → at user.quests.QuestRelicHunter.maps[0].remaining
```

The map object doesn't have a `remaining` prop, just  `map_id`, `name`, `hash`, `thumb`, `num_found`, `num_total`, `is_rare`, `is_complete`, `is_favourite`, `has_message`, `map_class`.

We're not actually using the `remaining` prop anywhere so it should be fine to drop it from the schema